### PR TITLE
Fix duplicate key errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Used unique `deviceStatus.id` for `_key` property of host agent ->
+  configuration relationships.
+
 ## 3.0.0 - 2020-03-18
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Used unique `deviceStatus.id` for `_key` property of host agent ->
   configuration relationships.
+- Used unique `deviceStatus.id` for `_key` property of device -> managed
+  application relationships.
 
 ## 3.0.0 - 2020-03-18
 

--- a/src/steps/intune/steps/applications/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/intune/steps/applications/__tests__/__snapshots__/index.test.ts.snap
@@ -13312,7 +13312,7 @@ Array [
   Object {
     "_class": "ASSIGNED",
     "_fromEntityKey": "683dbff1-c8ff-4996-91ae-85484de46cfc",
-    "_key": "683dbff1-c8ff-4996-91ae-85484de46cfc|assigned|IntuneManaged:google.com",
+    "_key": "50124056-8cca-4cf5-9f98-8e63bede0b6e683dbff1-c8ff-4996-91ae-85484de46cfc|683dbff1-c8ff-4996-91ae-85484de46cfc|IntuneManaged:google.com",
     "_toEntityKey": "IntuneManaged:google.com",
     "_type": "smartphone_assigned_intune_managed_application",
     "displayName": "ASSIGNED",
@@ -13324,7 +13324,7 @@ Array [
   Object {
     "_class": "ASSIGNED",
     "_fromEntityKey": "1f75329e-51fc-451c-bd40-c457337641a4",
-    "_key": "1f75329e-51fc-451c-bd40-c457337641a4|assigned|IntuneManaged:microsoft 365 apps for macos",
+    "_key": "55c4e44f-7e06-4586-8f4c-b1aebf301d321f75329e-51fc-451c-bd40-c457337641a4|1f75329e-51fc-451c-bd40-c457337641a4|IntuneManaged:microsoft 365 apps for macos",
     "_toEntityKey": "IntuneManaged:microsoft 365 apps for macos",
     "_type": "laptop_assigned_intune_managed_application",
     "displayName": "ASSIGNED",

--- a/src/steps/intune/steps/applications/index.ts
+++ b/src/steps/intune/steps/applications/index.ts
@@ -57,6 +57,12 @@ export async function fetchManagedApplications(
             from: deviceEntity,
             to: managedAppEntity,
             properties: {
+              _key:
+                deviceStatus.id! +
+                '|' +
+                deviceEntity._key +
+                '|' +
+                managedAppEntity._key,
               installState: deviceStatus.installState, // Possible values are: installed, failed, notInstalled, uninstallFailed, pendingInstall, & unknown
               installStateDetail: deviceStatus.installStateDetail, // extra details on the install state. Ex: iosAppStoreUpdateFailedToInstall
               errorCode: deviceStatus.errorCode,

--- a/src/steps/intune/steps/deviceConfigurationsAndFindings/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/intune/steps/deviceConfigurationsAndFindings/__tests__/__snapshots__/index.test.ts.snap
@@ -70,7 +70,7 @@ Array [
   Object {
     "_class": "ASSIGNED",
     "_fromEntityKey": "intune-host-agent:683dbff1-c8ff-4996-91ae-85484de46cfc",
-    "_key": "intune-host-agent:683dbff1-c8ff-4996-91ae-85484de46cfc|assigned|6aa605f0-744e-4ae1-8031-c6564624c89b",
+    "_key": "7b521133-f056-40a9-b639-b76afd67e4bb_6aa605f0-744e-4ae1-8031-c6564624c89b_683dbff1-c8ff-4996-91ae-85484de46cfc|intune-host-agent:683dbff1-c8ff-4996-91ae-85484de46cfc|6aa605f0-744e-4ae1-8031-c6564624c89b",
     "_toEntityKey": "6aa605f0-744e-4ae1-8031-c6564624c89b",
     "_type": "intune_host_agent_assigned_device_configuration",
     "complianceStatus": "error",

--- a/src/steps/intune/steps/deviceConfigurationsAndFindings/index.ts
+++ b/src/steps/intune/steps/deviceConfigurationsAndFindings/index.ts
@@ -68,6 +68,12 @@ export async function fetchDeviceConfigurationsAndFindings(
                 from: hostAgentEntity,
                 to: deviceConfigurationEntity,
                 properties: {
+                  _key:
+                    deviceStatus.id! +
+                    '|' +
+                    hostAgentEntity._key +
+                    '|' +
+                    deviceConfigurationEntity._key,
                   complianceStatus: deviceStatus.status,
                   compliant: [
                     ...UNRELATED_DEVICE_STATUSES,


### PR DESCRIPTION
Fixes https://github.com/JupiterOne/integrations/issues/7
Fixes https://github.com/JupiterOne/integrations/issues/31

```
### Changed

- Used unique `deviceStatus.id` for `_key` property of host agent ->
  configuration relationships.
- Used unique `deviceStatus.id` for `_key` property of device -> managed
  application relationships.
```