### PR TITLE
Stop sending callback errors to GraphClient.handleApiErrors(err)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to
   configuration relationships.
 - Used unique `deviceStatus.id` for `_key` property of device -> managed
   application relationships.
+- Reconfigured where the callback function is called in the client such that
+  callback errors (such as `DUPLICATE_KEY_ERROR`) are not sent to the
+  `handleApiError` method.
 
 ## 3.0.0 - 2020-03-18
 


### PR DESCRIPTION
While working on https://github.com/JupiterOne/graph-microsoft-365/pull/24, I noticed that duplicate key errors were being handled by `GraphClient.handleApiErrors(err)`, which I think makes working with this client somewhat confusing.

```
### Changed
- Reconfigured where the callback function is called in the client such that
  callback errors (such as `DUPLICATE_KEY_ERROR`) are not sent to the
  `handleApiError` method.
```