### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Changed
+## 3.0.1 - 2021-06-30
+
+### Fixed
 
 - Used unique `deviceStatus.id` for `_key` property of host agent ->
   configuration relationships.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format": "prettier --write '**/*.{ts,js,json,css,md,yml}'",
     "type-check": "tsc",
     "test": "jest",
+    "test:env": "LOAD_CONFIG=1 jest",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "prebuild": "yarn test:ci",
     "build": "tsc -p tsconfig.dist.json --declaration",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-microsoft-365",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A JupiterOne Integration for Microsoft 365",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,10 +1,18 @@
 import { IntegrationConfig } from '../src/types';
 
-export const config: IntegrationConfig = {
-  clientId: process.env.CLIENT_ID || 'clientId',
-  clientSecret: process.env.CLIENT_SECRET || 'clientSecret',
-  tenant: process.env.TENANT || 'a76fc728-0cba-45f0-a9eb-d45207e14513',
+const config: IntegrationConfig = {
+  clientId: 'clientId',
+  clientSecret: 'clientSecret',
+  tenant: 'a76fc728-0cba-45f0-a9eb-d45207e14513',
 };
+
+if (process.env.LOAD_CONFIG) {
+  config.clientId = process.env.CLIENT_ID || config.clientId;
+  config.clientSecret = process.env.CLIENT_SECRET || config.clientSecret;
+  config.tenant = process.env.TENANT || config.tenant;
+}
+
+export { config };
 
 /**
  * An integration config pointing at a directory that does not authorize the


### PR DESCRIPTION
```
## 3.0.1 - 2021-06-30

### Fixed

- Used unique `deviceStatus.id` for `_key` property of host agent ->
  configuration relationships.
- Used unique `deviceStatus.id` for `_key` property of device -> managed
  application relationships.
- Reconfigured where the callback function is called in the client such that
  callback errors (such as `DUPLICATE_KEY_ERROR`) are not sent to the
  `handleApiError` method.
```