### PR TITLE
Fix duplicate keys in intune_managed_application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Removed relationships between `intune_managed_application` and
+  `intune_detected_application` entities.
+
+### Fixed
+
+- Fixed duplicate key errors with `intune_managed_application` entities
+
 ## [3.0.8] - 2021-08-06
 
 ### Changed

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -191,7 +191,6 @@ The following relationships are created/mapped:
 | `intune_host_agent`           | **MANAGES**           | `smartphone`                   |
 | `intune_host_agent`           | **MANAGES**           | `user_endpoint`                |
 | `intune_host_agent`           | **MANAGES**           | `workstation`                  |
-| `intune_managed_application`  | **MANAGES**           | `intune_detected_application`  |
 | `laptop`                      | **ASSIGNED**          | `intune_managed_application`   |
 | `laptop`                      | **HAS**               | `intune_noncompliance_finding` |
 | `laptop`                      | **INSTALLED**         | `intune_detected_application`  |

--- a/src/steps/intune/steps/applications/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/intune/steps/applications/__tests__/__snapshots__/index.test.ts.snap
@@ -13294,26 +13294,13 @@ Array [
 ]
 `;
 
-exports[`fetchDetectedApplications should make entities and relationships correctly: managedAppDetectedAppRelationships 1`] = `
-Array [
-  Object {
-    "_class": "MANAGES",
-    "_fromEntityKey": "IntuneManaged:microsoft word",
-    "_key": "IntuneManaged:microsoft word|manages|IntuneDetected:microsoft word",
-    "_toEntityKey": "IntuneDetected:microsoft word",
-    "_type": "intune_managed_application_manages_detected_application",
-    "displayName": "MANAGES",
-  },
-]
-`;
-
 exports[`fetchManagedApplications should make entities and relationships correctly: deviceManagedApplicationRelationships 1`] = `
 Array [
   Object {
     "_class": "ASSIGNED",
     "_fromEntityKey": "683dbff1-c8ff-4996-91ae-85484de46cfc",
-    "_key": "50124056-8cca-4cf5-9f98-8e63bede0b6e683dbff1-c8ff-4996-91ae-85484de46cfc|683dbff1-c8ff-4996-91ae-85484de46cfc|IntuneManaged:google.com",
-    "_toEntityKey": "IntuneManaged:google.com",
+    "_key": "50124056-8cca-4cf5-9f98-8e63bede0b6e683dbff1-c8ff-4996-91ae-85484de46cfc|683dbff1-c8ff-4996-91ae-85484de46cfc|50124056-8cca-4cf5-9f98-8e63bede0b6e",
+    "_toEntityKey": "50124056-8cca-4cf5-9f98-8e63bede0b6e",
     "_type": "smartphone_assigned_intune_managed_application",
     "displayName": "ASSIGNED",
     "errorCode": 0,
@@ -13324,8 +13311,8 @@ Array [
   Object {
     "_class": "ASSIGNED",
     "_fromEntityKey": "1f75329e-51fc-451c-bd40-c457337641a4",
-    "_key": "55c4e44f-7e06-4586-8f4c-b1aebf301d321f75329e-51fc-451c-bd40-c457337641a4|1f75329e-51fc-451c-bd40-c457337641a4|IntuneManaged:microsoft 365 apps for macos",
-    "_toEntityKey": "IntuneManaged:microsoft 365 apps for macos",
+    "_key": "55c4e44f-7e06-4586-8f4c-b1aebf301d321f75329e-51fc-451c-bd40-c457337641a4|1f75329e-51fc-451c-bd40-c457337641a4|55c4e44f-7e06-4586-8f4c-b1aebf301d32",
+    "_toEntityKey": "55c4e44f-7e06-4586-8f4c-b1aebf301d32",
     "_type": "laptop_assigned_intune_managed_application",
     "displayName": "ASSIGNED",
     "errorCode": 0,
@@ -13343,7 +13330,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:com.android.vending.apk",
+    "_key": "cfbeb753-49e3-4ed5-9743-f857eb74df2a",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13427,7 +13414,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:google.com",
+    "_key": "50124056-8cca-4cf5-9f98-8e63bede0b6e",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13485,7 +13472,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:intune company portal",
+    "_key": "813a7159-4c66-4286-82f3-51b39aaefcd9",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13550,7 +13537,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:managed home screen",
+    "_key": "ccc52be9-a284-4f17-b669-f21a11bb4668",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13615,7 +13602,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:microsoft 365 apps for macos",
+    "_key": "55c4e44f-7e06-4586-8f4c-b1aebf301d32",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13671,7 +13658,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:microsoft 365 apps for windows 10",
+    "_key": "d88ed6fd-24da-406e-aba6-3e2c0c7a7e1d",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13757,7 +13744,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:microsoft authenticator",
+    "_key": "f9872827-46cb-4d02-80d8-063fa5a9588b",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13822,7 +13809,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:microsoft intune",
+    "_key": "d2c6709c-bec1-4e94-bcbc-0c7835ff19d9",
     "_rawData": Array [
       Object {
         "name": "default",
@@ -13887,7 +13874,7 @@ Array [
     "_class": Array [
       "Application",
     ],
-    "_key": "IntuneManaged:microsoft word",
+    "_key": "152c83ee-8d4d-4fd4-8cf3-62f7f6689ca0",
     "_rawData": Array [
       Object {
         "name": "default",

--- a/src/steps/intune/steps/applications/__tests__/index.test.ts
+++ b/src/steps/intune/steps/applications/__tests__/index.test.ts
@@ -89,11 +89,6 @@ describe('fetchDetectedApplications', () => {
           (c) => c._type,
         ).includes(r._type),
     );
-    const managedAppDetectedAppRelationships = context.jobState.collectedRelationships.filter(
-      (r) =>
-        relationships.MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION._type ===
-        r._type,
-    );
 
     // Check that we have Detected Applications
     expect(detectedApplicationEntities.length).toBeGreaterThan(0);
@@ -104,14 +99,21 @@ describe('fetchDetectedApplications', () => {
       'detectedApplicationEntities',
     );
 
-    // Check that we have MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION relationships
-    expect(managedAppDetectedAppRelationships.length).toBeGreaterThan(0);
-    expect(managedAppDetectedAppRelationships).toMatchDirectRelationshipSchema(
-      {},
-    );
-    expect(managedAppDetectedAppRelationships).toMatchSnapshot(
-      'managedAppDetectedAppRelationships',
-    );
+    // TODO add managed application -> detected appliation relationship
+    // const managedAppDetectedAppRelationships = context.jobState.collectedRelationships.filter(
+    //   (r) =>
+    //     relationships.MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION._type ===
+    //     r._type,
+    // );
+    //
+    // // Check that we have MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION relationships
+    // expect(managedAppDetectedAppRelationships.length).toBeGreaterThan(0);
+    // expect(managedAppDetectedAppRelationships).toMatchDirectRelationshipSchema(
+    //   {},
+    // );
+    // expect(managedAppDetectedAppRelationships).toMatchSnapshot(
+    //   'managedAppDetectedAppRelationships',
+    // );
 
     // Check that we have DEVICE_ASSIGNED_DETECTED_APPLICATION relationships
     expect(deviceDetectedApplicationRelationships.length).toBeGreaterThan(0);

--- a/src/steps/intune/steps/applications/converters.ts
+++ b/src/steps/intune/steps/applications/converters.ts
@@ -15,7 +15,6 @@ import {
 } from '@microsoft/microsoft-graph-types-beta';
 import { entities } from '../../constants';
 
-export const MANAGED_APP_KEY_PREFIX = 'IntuneManaged:';
 export const DETECTED_APP_KEY_PREFIX = 'IntuneDetected:';
 export const UNVERSIONED = 'unversioned';
 
@@ -34,12 +33,7 @@ export function createManagedApplicationEntity(
       assign: {
         _class: entities.MANAGED_APPLICATION._class,
         _type: entities.MANAGED_APPLICATION._type,
-        // The key needs to be the name of the application so it can be looked up when making managed -> detected app relationships.
-        // The managed app id is not available on the detected app so using it as the key here would make jobstate.findEntitiy not work.
-        // The prefix is necessary to ensure key is at least 10 characters
-        _key:
-          MANAGED_APP_KEY_PREFIX + managedApp.displayName?.toLowerCase() ??
-          managedApp.id, // Fallback to id if there is no name for the appds
+        _key: managedApp.id,
         id: managedApp.id,
         name: managedApp.displayName?.toLowerCase(),
         displayName: managedApp.displayName as string,

--- a/src/steps/intune/steps/applications/index.ts
+++ b/src/steps/intune/steps/applications/index.ts
@@ -4,8 +4,6 @@ import {
   createDirectRelationship,
   JobState,
   Entity,
-  generateRelationshipKey,
-  RelationshipClass,
 } from '@jupiterone/integration-sdk-core';
 import { IntegrationConfig, IntegrationStepContext } from '../../../../types';
 import {
@@ -19,7 +17,6 @@ import {
   createManagedApplicationEntity,
   DETECTED_APP_KEY_PREFIX,
   findNewestVersion,
-  MANAGED_APP_KEY_PREFIX,
   UNVERSIONED,
 } from './converters';
 import { DeviceManagementIntuneClient } from '../../clients/deviceManagementIntuneClient';
@@ -134,35 +131,36 @@ export async function fetchDetectedApplications(
             directRelationship._key += `|${detectedApp.id}`;
             await jobState.addRelationship(directRelationship);
 
-            // If there is a managed application related to this, create a MANAGES relationship
-            let managedAppEntity;
-            if (detectedApp.displayName?.toLowerCase) {
-              managedAppEntity = await jobState.findEntity(
-                MANAGED_APP_KEY_PREFIX + detectedApp.displayName?.toLowerCase(),
-              );
-            }
-            if (managedAppEntity) {
-              const managedAppManagesDetectedAppKey = generateRelationshipKey(
-                RelationshipClass.MANAGES,
-                managedAppEntity,
-                detectedAppEntity,
-              );
-              if (!(await jobState.hasKey(managedAppManagesDetectedAppKey))) {
-                await jobState.addRelationship(
-                  createDirectRelationship({
-                    _class:
-                      relationships
-                        .MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION
-                        ._class,
-                    from: managedAppEntity,
-                    to: detectedAppEntity,
-                    properties: {
-                      _key: managedAppManagesDetectedAppKey,
-                    },
-                  }),
-                );
-              }
-            }
+            // TODO create managed -> detected relationships
+            // // If there is a managed application related to this, create a MANAGES relationship
+            // let managedAppEntity;
+            // if (detectedApp.displayName?.toLowerCase) {
+            //   managedAppEntity = await jobState.findEntity(
+            //     MANAGED_APP_KEY_PREFIX + detectedApp.displayName?.toLowerCase(),
+            //   );
+            // }
+            // if (managedAppEntity) {
+            //   const managedAppManagesDetectedAppKey = generateRelationshipKey(
+            //     RelationshipClass.MANAGES,
+            //     managedAppEntity,
+            //     detectedAppEntity,
+            //   );
+            //   if (!(await jobState.hasKey(managedAppManagesDetectedAppKey))) {
+            //     await jobState.addRelationship(
+            //       createDirectRelationship({
+            //         _class:
+            //           relationships
+            //             .MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION
+            //             ._class,
+            //         from: managedAppEntity,
+            //         to: detectedAppEntity,
+            //         properties: {
+            //           _key: managedAppManagesDetectedAppKey,
+            //         },
+            //       }),
+            //     );
+            //   }
+            // }
           }
         },
       );

--- a/src/steps/intune/steps/applications/index.ts
+++ b/src/steps/intune/steps/applications/index.ts
@@ -202,7 +202,7 @@ export const applicationSteps: Step<
     entities: [entities.DETECTED_APPLICATION],
     relationships: [
       ...relationships.MULTI_DEVICE_INSTALLED_DETECTED_APPLICATION,
-      relationships.MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION,
+      // relationships.MANAGED_APPLICATION_MANAGES_DETECTED_APPLICATION,
     ],
     dependsOn: [steps.FETCH_DEVICES, steps.FETCH_MANAGED_APPLICATIONS],
     executionHandler: fetchDetectedApplications,


### PR DESCRIPTION
We cannot simply use an application `name` to create a unique `_key` in this integration, because different managed applications can have the same `name`. For example, **Adobe Acrobat Reader** can have two unique managed applications for different system types. 

<img width="806" alt="Screen Shot 2021-08-10 at 2 57 12 PM" src="https://user-images.githubusercontent.com/15333061/128919191-1ba34081-1116-4180-8aa1-6da8a0d76adc.png">

I reproduced a customer error by creating two managed applications of type **Adobe Acrobat Reader**:

<img width="777" alt="Screen Shot 2021-08-10 at 2 56 47 PM" src="https://user-images.githubusercontent.com/15333061/128919282-f0b31474-d4fb-413e-9ca3-1c38b74f0f47.png">

I strongly suspect that because this is the case, we cannot or should not create a link between `intune_managed_application` and `intune_detected_application`, and I have removed this relationship at least temporarily. I verified that just one J1 user actually has relationships between `intune_managed_application` and `intune_detected_application`, and that happens to be the same user that is experiencing the `DUPLICATE_KEY_ERROR` that this PR remediates.