### PR TITLE
Changelog for 3.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [3.0.9] - 2021-08-11
+
 ### Changed
 
 - Removed relationships between `intune_managed_application` and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-microsoft-365",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "A JupiterOne Integration for Microsoft 365",
   "license": "MPL-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
```
### Changed

- Removed relationships between `intune_managed_application` and
  `intune_detected_application` entities.

### Fixed

- Fixed duplicate key errors with `intune_managed_application` entities
- Deduplicate `intune_host_agent_assigned_compliance_policy` relationships
- Deduplicate `intune_noncompliance_finding` entities
```

NOTE: Even though there is a removed relationship, I analyzed the 4 accounts that use this integration and they don't actually have this relationship.