### PR TITLE
Add steps spec

### DIFF
--- a/docs/spec/src/index.ts
+++ b/docs/spec/src/index.ts
@@ -1,0 +1,177 @@
+import {
+  IntegrationInvocationConfig,
+  IntegrationStepExecutionContext,
+  RelationshipClass,
+  RelationshipDirection,
+  Step,
+} from '@jupiterone/integration-sdk-core';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const executionHandler = () => {};
+
+export const invocationConfig: IntegrationInvocationConfig = {
+  integrationSteps: [
+    /**
+     * ENDPOINT: n/a
+     * PATTERN: Singleton
+     */
+    {
+      id: 'create-account',
+      name: 'Create Account',
+      entities: [
+        {
+          resourceName: 'Account',
+          _class: 'Account',
+          _type: 'intune_account',
+        },
+      ],
+      relationships: [],
+      mappedRelationships: [
+        {
+          _type: 'microsoft_tenant_has_intune_account',
+          sourceType: 'intune_account',
+          _class: RelationshipClass.HAS,
+          targetType: 'microsoft_tenant',
+          relationshipDirection: RelationshipDirection.REVERSE,
+        },
+      ],
+      dependsOn: [],
+      executionHandler,
+    } as Step<IntegrationStepExecutionContext>,
+    /**
+     * ENDPOINT: '/deviceManagement/managedDevices',
+     * PATTERN: Fetch Entitites,
+     */
+    {
+      id: 'fetch-managed-devices',
+      name: 'Fetch Managed Devices',
+      entities: [
+        {
+          resourceName: 'Device',
+          _class: 'Device',
+          _type: 'intune_device',
+        },
+      ],
+      relationships: [
+        {
+          _type: 'intune_account_has_device',
+          sourceType: 'intune_account',
+          _class: RelationshipClass.HAS,
+          targetType: 'intune_device',
+        },
+      ],
+      dependsOn: ['create-account'],
+      executionHandler,
+    },
+    /**
+     * ENDPOINT: '/deviceManagement/deviceCompliancePolicies',
+     * PATTERN: Fetch Entitites,
+     */
+    {
+      id: 'fetch-compliance-policies',
+      name: 'Fetch Compliance Policies',
+      entities: [
+        {
+          resourceName: 'Compliance Policy',
+          _class: ['Configuration', 'ControlPolicy'],
+          _type: 'intune_compliance_policy',
+        },
+      ],
+      relationships: [
+        {
+          _type: 'intune_account_has_compliance_policy',
+          sourceType: 'intune_account',
+          _class: RelationshipClass.HAS,
+          targetType: 'intune_compliance_policy',
+        },
+      ],
+      dependsOn: ['create-account'],
+      executionHandler,
+    },
+    /**
+     * ENDPOINT: '/deviceManagement/deviceConfigurations',
+     * PATTERN: Fetch Entitites,
+     */
+    {
+      id: 'fetch-device-configurations',
+      name: 'Fetch Device Configurations',
+      entities: [
+        {
+          resourceName: 'Device Confguration',
+          _class: ['Configuration', 'ControlPolicy'],
+          _type: 'intune_device_configuration',
+        },
+      ],
+      relationships: [
+        {
+          _type: 'intune_account_has_device_configuration',
+          sourceType: 'intune_account',
+          _class: RelationshipClass.HAS,
+          targetType: 'intune_device_configuration',
+        },
+      ],
+      dependsOn: ['create-account'],
+      executionHandler,
+    },
+    /**
+     * ENDPOINT: '/deviceManagement/managedDevices/{deviceId}/deviceCompliancePolicyStates',
+     * PATTERN: Fetch Child Entitites,
+     */
+    {
+      id: 'fetch-compliance-policy-states',
+      name: 'Fetch Compliance Policy States',
+      entities: [
+        {
+          resourceName: 'Compliance Policy State',
+          _class: ['Finding'],
+          _type: 'intune_compliance_policy_state',
+        },
+      ],
+      relationships: [
+        {
+          _type: 'intune_device_has_compliance_policy_state',
+          sourceType: 'intune_device',
+          _class: RelationshipClass.HAS,
+          targetType: 'intune_compliance_policy_state',
+        },
+        {
+          _type: 'intune_compliance_policy_identified_state',
+          sourceType: 'intune_compliance_policy',
+          _class: RelationshipClass.IDENTIFIED,
+          targetType: 'intune_compliance_policy_state',
+        },
+      ],
+      executionHandler,
+    },
+    /**
+     * ENDPOINT: '/deviceManagement/managedDevices/{deviceId}/deviceConfigurationStates',
+     * PATTERN: Fetch Child Entitites,
+     */
+    {
+      id: 'fetch-device-configuration-states',
+      name: 'Fetch Device Configuration States',
+      entities: [
+        {
+          resourceName: 'Device Configuration State',
+          _class: ['Finding'],
+          _type: 'intune_device_configuration_state',
+        },
+      ],
+      relationships: [
+        {
+          _type: 'intune_device_has_configuration_state',
+          sourceType: 'intune_device',
+          _class: RelationshipClass.HAS,
+          targetType: 'intune_device_configuration_state',
+        },
+        {
+          _type: 'intune_device_configuration_identified_state',
+          sourceType: 'intune_device_configuration',
+          _class: RelationshipClass.IDENTIFIED,
+          targetType: 'intune_device_configuration_state',
+        },
+      ],
+      executionHandler,
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "start": "j1-integration collect",
     "graph": "j1-integration visualize",
+    "visualize-types": "j1-integration visualize-types",
+    "visualize-spec": "j1-integration visualize-types -p docs/spec -o .j1-integration/types-graph/index.spec.html",
     "lint": "eslint . --cache --fix --ext .ts,.tsx",
     "format": "prettier --write '**/*.{ts,js,json,css,md,yml}'",
     "type-check": "tsc",


### PR DESCRIPTION
I would like to move towards building an integration spec alongside integration code. This spec represents much of the J1 specific context that is difficult for a new developer to internalize, including:

- decisions on entity/relationship classes & types
- important entities and relationships to ingest

In addition, I've added to this spec both an optional `ENDPOINT` associated with each step, as well as a `PATTERN` (where integration step patterns are defined here: https://github.com/JupiterOne/sdk/pull/484)

In particular, this effort materialized when I spent some time trying to understand why the MS365 integration has so much code to deduplicate entities, and I determined that this could be refactored to use the standard `PATTERN`s and simplify the integration while eliminating all of the duplicate key errors we're seeing.

By adding a specification to integrations, we have a longer pipeline (request -> spec written -> code written), including a work stream that could be more effectively handled by product teams. We also can use existing automation to manually review the differences between the integration spec & implementation (using `j1-integration visualize-types`) or build new automation to computationally compare the integration spec & implementation.

See `yarn j1-integration visualize-types` difference between spec & implementation:

![Screen Shot 2021-08-11 at 3 21 48 PM](https://user-images.githubusercontent.com/15333061/129090397-e44bde9d-9ff3-44ec-b6f9-2d6447cfe871.png)

![Screen Shot 2021-08-11 at 3 23 42 PM](https://user-images.githubusercontent.com/15333061/129090404-98c4b888-d605-48c9-91d9-f4fce0d57d65.png)
