### PR TITLE
[INT-2841] duplicate key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## Unreleased
 
+## 4.0.2 - 2022-03-11
+
+## Fixed
+
+- Removed `raw_data` from Detected Application Entity
+- Added duplicate key check in `detected-applications` step
+
 ## 4.0.1 - 2021-10-30
 
 - Add a few development conveniences

--- a/src/steps/intune/steps/applications/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/intune/steps/applications/__tests__/__snapshots__/index.test.ts.snap
@@ -7,22 +7,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft word",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft Word",
-          "id": "8c130ff7cce5e6f16b5d7ca1f117b8a6fad3a53d653b7934f315e5bfaaf45143",
-          "sizeInByte": 2188603541,
-          "version": "16.46",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft Word",
-    "id": "8c130ff7cce5e6f16b5d7ca1f117b8a6fad3a53d653b7934f315e5bfaaf45143",
     "name": "microsoft word",
   },
   Object {
@@ -30,22 +18,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft outlook",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft Outlook",
-          "id": "77221bd3937100ca0aa0328e8cc6a747c0c8054d61bccd4f251adec607f849d0",
-          "sizeInByte": 2011498633,
-          "version": "16.46",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft Outlook",
-    "id": "77221bd3937100ca0aa0328e8cc6a747c0c8054d61bccd4f251adec607f849d0",
     "name": "microsoft outlook",
   },
   Object {
@@ -53,22 +29,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft onenote",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft OneNote",
-          "id": "fb394f34436b864589fae7b57a16fa56c97bd1e2779beba96765ff88448d3f97",
-          "sizeInByte": 1036771988,
-          "version": "16.46",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft OneNote",
-    "id": "fb394f34436b864589fae7b57a16fa56c97bd1e2779beba96765ff88448d3f97",
     "name": "microsoft onenote",
   },
   Object {
@@ -76,22 +40,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft excel",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft Excel",
-          "id": "8a38d779a0d9d9444a7be104c2dd60cb7e8c9dbba45e8bf40a9a91db358dd0c0",
-          "sizeInByte": 1917511140,
-          "version": "16.46",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft Excel",
-    "id": "8a38d779a0d9d9444a7be104c2dd60cb7e8c9dbba45e8bf40a9a91db358dd0c0",
     "name": "microsoft excel",
   },
   Object {
@@ -99,22 +51,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft powerpoint",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft PowerPoint",
-          "id": "adcf0312b5c51b45c1168e94d2a4bd931081883ae79be774f2627cccd589c5d7",
-          "sizeInByte": 1663667341,
-          "version": "16.46",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft PowerPoint",
-    "id": "adcf0312b5c51b45c1168e94d2a4bd931081883ae79be774f2627cccd589c5d7",
     "name": "microsoft powerpoint",
   },
   Object {
@@ -122,22 +62,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:google chrome",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Google Chrome",
-          "id": "191e0e61d75e11a723446333c48c40e628e067f2c0fbca2de1db80e20e805759",
-          "sizeInByte": 487596197,
-          "version": "88.0.4324.182",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Google Chrome",
-    "id": "191e0e61d75e11a723446333c48c40e628e067f2c0fbca2de1db80e20e805759",
     "name": "google chrome",
   },
   Object {
@@ -145,22 +73,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:zoom.us",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "zoom.us",
-          "id": "17ec05889925b40e69c96da00a645234b06d65cdb95a20d837a5b1d20d0e0d51",
-          "sizeInByte": 128443815,
-          "version": "5.4.9 (59931.0110)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "zoom.us",
-    "id": "17ec05889925b40e69c96da00a645234b06d65cdb95a20d837a5b1d20d0e0d51",
     "name": "zoom.us",
   },
   Object {
@@ -168,22 +84,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft autoupdate",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft AutoUpdate",
-          "id": "637910607e361d7b06717b9296bba875f76a45e717c9862a9be2ca72d665c6e5",
-          "sizeInByte": 29387316,
-          "version": "4.31",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft AutoUpdate",
-    "id": "637910607e361d7b06717b9296bba875f76a45e717c9862a9be2ca72d665c6e5",
     "name": "microsoft autoupdate",
   },
   Object {
@@ -191,22 +95,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft edge",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft Edge",
-          "id": "a706928ebc3f8be92ab34d1fa8762510e3973420f930b3d0805107cbd6e0add5",
-          "sizeInByte": 392452906,
-          "version": "88.0.705.68",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft Edge",
-    "id": "a706928ebc3f8be92ab34d1fa8762510e3973420f930b3d0805107cbd6e0add5",
     "name": "microsoft edge",
   },
   Object {
@@ -214,22 +106,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:sublime text",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Sublime Text",
-          "id": "4c3a4543c11ca5f07f5abf985af2ba1d27511f031ddba3fad25d9371449530cb",
-          "sizeInByte": 43780747,
-          "version": "Build 3211",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Sublime Text",
-    "id": "4c3a4543c11ca5f07f5abf985af2ba1d27511f031ddba3fad25d9371449530cb",
     "name": "sublime text",
   },
   Object {
@@ -237,22 +117,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:postman agent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Postman Agent",
-          "id": "97943665af3408c134b3f40328bd76b35a0cc0153e664cc696b1d0dafb890bb8",
-          "sizeInByte": 262806015,
-          "version": "0.3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Postman Agent",
-    "id": "97943665af3408c134b3f40328bd76b35a0cc0153e664cc696b1d0dafb890bb8",
     "name": "postman agent",
   },
   Object {
@@ -260,22 +128,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:vmware cbcloud",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VMware CBCloud",
-          "id": "d12153a0bcc01396461b0bab009cc3cb985d4299562da9c922344e0d5aee135b",
-          "sizeInByte": 1333351,
-          "version": "3.5.1fc19",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VMware CBCloud",
-    "id": "d12153a0bcc01396461b0bab009cc3cb985d4299562da9c922344e0d5aee135b",
     "name": "vmware cbcloud",
   },
   Object {
@@ -283,22 +139,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:airscanlegacydiscovery",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AirScanLegacyDiscovery",
-          "id": "283b0e0f5580d59a2ada5b64a7e1ce0016d20965a75ff7cbf6f42269174b38ac",
-          "sizeInByte": 126519,
-          "version": "16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AirScanLegacyDiscovery",
-    "id": "283b0e0f5580d59a2ada5b64a7e1ce0016d20965a75ff7cbf6f42269174b38ac",
     "name": "airscanlegacydiscovery",
   },
   Object {
@@ -306,22 +150,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mobiledeviceupdater",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MobileDeviceUpdater",
-          "id": "8afe44f89c6e25f928238da674d84ce407351126a898e072e3470d395102676d",
-          "sizeInByte": 1347789,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MobileDeviceUpdater",
-    "id": "8afe44f89c6e25f928238da674d84ce407351126a898e072e3470d395102676d",
     "name": "mobiledeviceupdater",
   },
   Object {
@@ -329,22 +161,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:onedrive",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OneDrive",
-          "id": "6db59c3d89dfc53da0c43538e659ebbd9f04b8f66768b9f7fbc618b3ffc12419",
-          "sizeInByte": 236340634,
-          "version": "21.002.0104",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OneDrive",
-    "id": "6db59c3d89dfc53da0c43538e659ebbd9f04b8f66768b9f7fbc618b3ffc12419",
     "name": "onedrive",
   },
   Object {
@@ -352,22 +172,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:xcode",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Xcode",
-          "id": "d30f3014d86e5cd56218dc9faf41d6cf22a17c4ad7a3acf2eec65bc3ad5707d9",
-          "sizeInByte": 29335600116,
-          "version": "12.4",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Xcode",
-    "id": "d30f3014d86e5cd56218dc9faf41d6cf22a17c4ad7a3acf2eec65bc3ad5707d9",
     "name": "xcode",
   },
   Object {
@@ -375,22 +183,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:docker",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Docker",
-          "id": "81661bc3f5847235832e199733784de580255042a6b0216aca24a45e2c776243",
-          "sizeInByte": 1401241394,
-          "version": "3.0.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Docker",
-    "id": "81661bc3f5847235832e199733784de580255042a6b0216aca24a45e2c776243",
     "name": "docker",
   },
   Object {
@@ -398,22 +194,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:spotify",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Spotify",
-          "id": "dcf92b9f286e6f50172cd1f337ec97ebb3f120a7dda15fce354d20dcc1759c60",
-          "sizeInByte": 283257144,
-          "version": "1.1.48.625.g1c87c7f7",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Spotify",
-    "id": "dcf92b9f286e6f50172cd1f337ec97ebb3f120a7dda15fce354d20dcc1759c60",
     "name": "spotify",
   },
   Object {
@@ -421,22 +205,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:skype for business",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Skype for Business",
-          "id": "a835a61d5425fe3ae1d65d6e34f5cf8355a6867eebdeaa6476cd8f057550ae56",
-          "sizeInByte": 94189171,
-          "version": "16.29.42",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Skype for Business",
-    "id": "a835a61d5425fe3ae1d65d6e34f5cf8355a6867eebdeaa6476cd8f057550ae56",
     "name": "skype for business",
   },
   Object {
@@ -444,22 +216,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:keybase",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Keybase",
-          "id": "11ddf4f534aff82743cb18fadbc319a891f66f43b67eca89989851db2b4b474a",
-          "sizeInByte": 481129024,
-          "version": "5.6.2-20210202191343+d72cc00cd3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Keybase",
-    "id": "11ddf4f534aff82743cb18fadbc319a891f66f43b67eca89989851db2b4b474a",
     "name": "keybase",
   },
   Object {
@@ -467,22 +227,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pritunl",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Pritunl",
-          "id": "52ccae6d337966e2f51e19e91fa98413549c64e86a4bcc21e3f1c8da1efe3e6b",
-          "sizeInByte": 202688,
-          "version": "1.2.2615.73",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Pritunl",
-    "id": "52ccae6d337966e2f51e19e91fa98413549c64e86a4bcc21e3f1c8da1efe3e6b",
     "name": "pritunl",
   },
   Object {
@@ -490,22 +238,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:insomnia",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Insomnia",
-          "id": "41e517e35cbf059e00cb74a704037b67443da38fc3931f089d0ab18205a0f869",
-          "sizeInByte": 357348452,
-          "version": "2020.5.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Insomnia",
-    "id": "41e517e35cbf059e00cb74a704037b67443da38fc3931f089d0ab18205a0f869",
     "name": "insomnia",
   },
   Object {
@@ -513,22 +249,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:gitkraken",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "GitKraken",
-          "id": "242f081234404c002bbe90906dfcbef0f7384e9f8ca6e5ba345cb932f2854c1e",
-          "sizeInByte": 273473670,
-          "version": "7.4.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "GitKraken",
-    "id": "242f081234404c002bbe90906dfcbef0f7384e9f8ca6e5ba345cb932f2854c1e",
     "name": "gitkraken",
   },
   Object {
@@ -536,22 +260,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:visual studio code",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Visual Studio Code",
-          "id": "1efe0fc4e111bcbe4b2f970ea06eb73a4c081afd4433a9439df8c41e95f38818",
-          "sizeInByte": 269322972,
-          "version": "1.53.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Visual Studio Code",
-    "id": "1efe0fc4e111bcbe4b2f970ea06eb73a4c081afd4433a9439df8c41e95f38818",
     "name": "visual studio code",
   },
   Object {
@@ -559,22 +271,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:slack",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Slack",
-          "id": "fc5034f3b9fc5d3da5ab755e96389e822feb91e1e9874761f6a8b3b7be20a62e",
-          "sizeInByte": 379011218,
-          "version": "4.12.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Slack",
-    "id": "fc5034f3b9fc5d3da5ab755e96389e822feb91e1e9874761f6a8b3b7be20a62e",
     "name": "slack",
   },
   Object {
@@ -582,22 +282,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mrt",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MRT",
-          "id": "2067b397da2d894d4f2ca2bce993786548944627269274cbdc81814bef294f55",
-          "sizeInByte": 14688716,
-          "version": "1.73",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MRT",
-    "id": "2067b397da2d894d4f2ca2bce993786548944627269274cbdc81814bef294f55",
     "name": "mrt",
   },
   Object {
@@ -605,22 +293,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft remote desktop",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft Remote Desktop",
-          "id": "1c9f060f49469b809cf9de756b56cb9b70af7270bdd653bd2b6d68aa2b08eb07",
-          "sizeInByte": 52359902,
-          "version": "10.5.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft Remote Desktop",
-    "id": "1c9f060f49469b809cf9de756b56cb9b70af7270bdd653bd2b6d68aa2b08eb07",
     "name": "microsoft remote desktop",
   },
   Object {
@@ -628,22 +304,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:stethoscope",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Stethoscope",
-          "id": "72d74931cfdf33dbe604d9a75690f64fd515125b01170768b20a7ab073352860",
-          "sizeInByte": 203879712,
-          "version": "4.0.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Stethoscope",
-    "id": "72d74931cfdf33dbe604d9a75690f64fd515125b01170768b20a7ab073352860",
     "name": "stethoscope",
   },
   Object {
@@ -651,22 +315,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pages",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Pages",
-          "id": "abc0c125045cb6214f523cf8c63304c8886bf93d58029d94399339294bada2a7",
-          "sizeInByte": 546361731,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Pages",
-    "id": "abc0c125045cb6214f523cf8c63304c8886bf93d58029d94399339294bada2a7",
     "name": "pages",
   },
   Object {
@@ -674,22 +326,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:numbers",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Numbers",
-          "id": "805bd3196f7810ab756207c98e9cdd35836b5707394a0a31711707149dc34acc",
-          "sizeInByte": 446896301,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Numbers",
-    "id": "805bd3196f7810ab756207c98e9cdd35836b5707394a0a31711707149dc34acc",
     "name": "numbers",
   },
   Object {
@@ -697,22 +337,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:garageband",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "GarageBand",
-          "id": "aedc4cc0969920b30a6b194ff374500ff275b1f1c9e7f0515f23da2d58bac184",
-          "sizeInByte": 1452265686,
-          "version": "10.3.4",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "GarageBand",
-    "id": "aedc4cc0969920b30a6b194ff374500ff275b1f1c9e7f0515f23da2d58bac184",
     "name": "garageband",
   },
   Object {
@@ -720,22 +348,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:imovie",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "iMovie",
-          "id": "b21858615a1ab52884eec74b7262cdd86cd6f824957131f67a27769187553d46",
-          "sizeInByte": 2772072926,
-          "version": "10.2.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "iMovie",
-    "id": "b21858615a1ab52884eec74b7262cdd86cd6f824957131f67a27769187553d46",
     "name": "imovie",
   },
   Object {
@@ -743,22 +359,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:keynote",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Keynote",
-          "id": "7ff51ae8ab0e8801812c10a57cea2ce4c6e0da025cc4c01ef735a28c4faae237",
-          "sizeInByte": 666508352,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Keynote",
-    "id": "7ff51ae8ab0e8801812c10a57cea2ce4c6e0da025cc4c01ef735a28c4faae237",
     "name": "keynote",
   },
   Object {
@@ -766,22 +370,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:safari",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Safari",
-          "id": "3cbc0c2af6632d19f01beb330881217a1ad066b9887c4cbde8cc33466041c4fe",
-          "sizeInByte": 19347621,
-          "version": "14.0.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Safari",
-    "id": "3cbc0c2af6632d19f01beb330881217a1ad066b9887c4cbde8cc33466041c4fe",
     "name": "safari",
   },
   Object {
@@ -789,22 +381,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:reality composer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Reality Composer",
-          "id": "23762d51807d400892a3ca30cf2c9878bfe79601addf682224ac9380d8e9d718",
-          "sizeInByte": 0,
-          "version": "1.5",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Reality Composer",
-    "id": "23762d51807d400892a3ca30cf2c9878bfe79601addf682224ac9380d8e9d718",
     "name": "reality composer",
   },
   Object {
@@ -812,22 +392,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:accessibility inspector",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Accessibility Inspector",
-          "id": "cd1019fb90ad2864706193c01dd189588595581b70ddb2660a8b76b3697b97c5",
-          "sizeInByte": 0,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Accessibility Inspector",
-    "id": "cd1019fb90ad2864706193c01dd189588595581b70ddb2660a8b76b3697b97c5",
     "name": "accessibility inspector",
   },
   Object {
@@ -835,22 +403,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:filemerge",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FileMerge",
-          "id": "395c9239f0e6a081274dd83b828fbb198c08f256745c38af1b4d869cc11657d5",
-          "sizeInByte": 0,
-          "version": "2.11",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FileMerge",
-    "id": "395c9239f0e6a081274dd83b828fbb198c08f256745c38af1b4d869cc11657d5",
     "name": "filemerge",
   },
   Object {
@@ -858,22 +414,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:instruments",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Instruments",
-          "id": "47806dcced99b963154eb4ba4cf266ed5b0a40a17b49b67d1e745e477c702a23",
-          "sizeInByte": 0,
-          "version": "12.4",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Instruments",
-    "id": "47806dcced99b963154eb4ba4cf266ed5b0a40a17b49b67d1e745e477c702a23",
     "name": "instruments",
   },
   Object {
@@ -881,22 +425,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:create ml",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Create ML",
-          "id": "60e7b6d5c76a2f9b440a94d8bc82b6da08f10d60825dc73a393d66bd7a25261c",
-          "sizeInByte": 0,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Create ML",
-    "id": "60e7b6d5c76a2f9b440a94d8bc82b6da08f10d60825dc73a393d66bd7a25261c",
     "name": "create ml",
   },
   Object {
@@ -904,22 +436,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:powershell",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PowerShell",
-          "id": "2a46b8280f2fd1fee09b64bb73aefd5b2e5e85100982b1fff95392835cd5015f",
-          "sizeInByte": 274534,
-          "version": "7.1.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PowerShell",
-    "id": "2a46b8280f2fd1fee09b64bb73aefd5b2e5e85100982b1fff95392835cd5015f",
     "name": "powershell",
   },
   Object {
@@ -927,22 +447,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:cocoa-applescript applet",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Cocoa-AppleScript Applet",
-          "id": "8f4e6bb5f334b445e653bdff5ce13a4ed40b33e04bd7639779916df303a9b8d9",
-          "sizeInByte": 456936,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Cocoa-AppleScript Applet",
-    "id": "8f4e6bb5f334b445e653bdff5ce13a4ed40b33e04bd7639779916df303a9b8d9",
     "name": "cocoa-applescript applet",
   },
   Object {
@@ -950,22 +458,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:recursive image file processing droplet",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Recursive Image File Processing Droplet",
-          "id": "f8b95c4d8c055374b8414b419b928c6b9a8f29d03783939fcf4d8e944640a084",
-          "sizeInByte": 65400,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Recursive Image File Processing Droplet",
-    "id": "f8b95c4d8c055374b8414b419b928c6b9a8f29d03783939fcf4d8e944640a084",
     "name": "recursive image file processing droplet",
   },
   Object {
@@ -973,22 +469,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:droplet with settable properties",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Droplet with Settable Properties",
-          "id": "bec808857c81050618e69e5257a177e313d22e80164569c09777623bb31bceb5",
-          "sizeInByte": 61314,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Droplet with Settable Properties",
-    "id": "bec808857c81050618e69e5257a177e313d22e80164569c09777623bb31bceb5",
     "name": "droplet with settable properties",
   },
   Object {
@@ -996,22 +480,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:recursive file processing droplet",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Recursive File Processing Droplet",
-          "id": "6fc380290daad55172ae3db8d8672883f4d8ea15db7e89388e0ba300bc502fe2",
-          "sizeInByte": 65550,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Recursive File Processing Droplet",
-    "id": "6fc380290daad55172ae3db8d8672883f4d8ea15db7e89388e0ba300bc502fe2",
     "name": "recursive file processing droplet",
   },
   Object {
@@ -1019,22 +491,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:applemobilesync",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AppleMobileSync",
-          "id": "bf01c6b114648d2ec24fac303f750066219748efe907f9f7a355a5e7469ff67f",
-          "sizeInByte": 549389,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AppleMobileSync",
-    "id": "bf01c6b114648d2ec24fac303f750066219748efe907f9f7a355a5e7469ff67f",
     "name": "applemobilesync",
   },
   Object {
@@ -1042,22 +502,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:applemobiledevicehelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AppleMobileDeviceHelper",
-          "id": "851c08ef20b6d26c9c4ed72ad95cc2823c7d78b5f5d175e10eef5a10a4bae177",
-          "sizeInByte": 1075817,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AppleMobileDeviceHelper",
-    "id": "851c08ef20b6d26c9c4ed72ad95cc2823c7d78b5f5d175e10eef5a10a4bae177",
     "name": "applemobiledevicehelper",
   },
   Object {
@@ -1065,22 +513,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:fax receive monitor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Fax Receive Monitor",
-          "id": "44b7feee1533c221455056b02cb0715ed5e4038b5a96a87bd6a34092af42275f",
-          "sizeInByte": 1082173,
-          "version": "1.71",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Fax Receive Monitor",
-    "id": "44b7feee1533c221455056b02cb0715ed5e4038b5a96a87bd6a34092af42275f",
     "name": "fax receive monitor",
   },
   Object {
@@ -1088,22 +524,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:fax utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FAX Utility",
-          "id": "3684c7a563b1066c9b339d0a118abcc705e598be6569f24b62205446980f7ac5",
-          "sizeInByte": 539760,
-          "version": "1.73",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FAX Utility",
-    "id": "3684c7a563b1066c9b339d0a118abcc705e598be6569f24b62205446980f7ac5",
     "name": "fax utility",
   },
   Object {
@@ -1111,22 +535,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:epfaxautosetuptool",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "EPFaxAutoSetupTool",
-          "id": "b4ae9bf89a5142a6c4e5d249b1cefbdfb00abc579c242a31b8384ef3253f5a37",
-          "sizeInByte": 46355,
-          "version": "1.71",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "EPFaxAutoSetupTool",
-    "id": "b4ae9bf89a5142a6c4e5d249b1cefbdfb00abc579c242a31b8384ef3253f5a37",
     "name": "epfaxautosetuptool",
   },
   Object {
@@ -1134,22 +546,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:commandfilter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "commandFilter",
-          "id": "e6b4fd17a243efc12f3dbb4916f871d1999fb20c29b5e9696afecc37671d9b70",
-          "sizeInByte": 86447,
-          "version": "1.71",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "commandFilter",
-    "id": "e6b4fd17a243efc12f3dbb4916f871d1999fb20c29b5e9696afecc37671d9b70",
     "name": "commandfilter",
   },
   Object {
@@ -1157,22 +557,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:rastertoepfax",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "rastertoepfax",
-          "id": "f8e73bca365edc164758d3b3a69b34033db49e884f4a33c8b4c9aaf024bdbae5",
-          "sizeInByte": 296548,
-          "version": "1.71",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "rastertoepfax",
-    "id": "f8e73bca365edc164758d3b3a69b34033db49e884f4a33c8b4c9aaf024bdbae5",
     "name": "rastertoepfax",
   },
   Object {
@@ -1180,22 +568,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:epsonfax",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "epsonfax",
-          "id": "1ab571e6254f455c5b418368c05549cbae32b743ab9d6e715d02e1e086383d93",
-          "sizeInByte": 41837,
-          "version": "1.71",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "epsonfax",
-    "id": "1ab571e6254f455c5b418368c05549cbae32b743ab9d6e715d02e1e086383d93",
     "name": "epsonfax",
   },
   Object {
@@ -1203,22 +579,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:simulator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Simulator",
-          "id": "542d25fe9c84e1f75124144b10eca8203631b5133511f8f693364683eedb7238",
-          "sizeInByte": 0,
-          "version": "12.4",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Simulator",
-    "id": "542d25fe9c84e1f75124144b10eca8203631b5133511f8f693364683eedb7238",
     "name": "simulator",
   },
   Object {
@@ -1226,22 +590,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:xcode server builder",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Xcode Server Builder",
-          "id": "aa34ffe43bc60e1a46ecdce4fc31ce7564fa28c1441783a89a0e04d8b5f30d95",
-          "sizeInByte": 0,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Xcode Server Builder",
-    "id": "aa34ffe43bc60e1a46ecdce4fc31ce7564fa28c1441783a89a0e04d8b5f30d95",
     "name": "xcode server builder",
   },
   Object {
@@ -1249,22 +601,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:python launcher 3",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Python Launcher 3",
-          "id": "c2fe6050e6079ffc59c3e2fa2fe8a0fe6221e6da4581b0ef8d9e60dbb36898ee",
-          "sizeInByte": 261235,
-          "version": "3.9.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Python Launcher 3",
-    "id": "c2fe6050e6079ffc59c3e2fa2fe8a0fe6221e6da4581b0ef8d9e60dbb36898ee",
     "name": "python launcher 3",
   },
   Object {
@@ -1272,22 +612,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:idle 3",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "IDLE 3",
-          "id": "587d49e17b02f9b94522111e03ceaed7ed6c65a70829fc599ebab3674c1cb86e",
-          "sizeInByte": 174156,
-          "version": "3.9.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "IDLE 3",
-    "id": "587d49e17b02f9b94522111e03ceaed7ed6c65a70829fc599ebab3674c1cb86e",
     "name": "idle 3",
   },
   Object {
@@ -1295,22 +623,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:python",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Python",
-          "id": "664390921dd85de851124e18d3756f7e9ec8cee388ef6294b5adacf94e98d67b",
-          "sizeInByte": 156982,
-          "version": "3.9.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Python",
-    "id": "664390921dd85de851124e18d3756f7e9ec8cee388ef6294b5adacf94e98d67b",
     "name": "python",
   },
   Object {
@@ -1318,22 +634,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft.netcore.app.app",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft.NETCore.App.app",
-          "id": "849a5a92b08cb014c5346ba3b3298029ce2ba2d237e81a2f53f0b4861bab880e",
-          "sizeInByte": 71557000,
-          "version": null,
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft.NETCore.App.app",
-    "id": "849a5a92b08cb014c5346ba3b3298029ce2ba2d237e81a2f53f0b4861bab880e",
     "name": "microsoft.netcore.app.app",
   },
   Object {
@@ -1341,22 +645,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:install spotify",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Install Spotify",
-          "id": "a37188d62d660b6a3a07a345cf354e2c6b9375fc68f3bba5d0ac87d1e4110eaf",
-          "sizeInByte": 1102056,
-          "version": "1.1.48.625.g1c87c7f7",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Install Spotify",
-    "id": "a37188d62d660b6a3a07a345cf354e2c6b9375fc68f3bba5d0ac87d1e4110eaf",
     "name": "install spotify",
   },
   Object {
@@ -1364,22 +656,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:spectacle",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Spectacle",
-          "id": "2de49589933c27cb427856dffe408881c7f4f7e243d87041d98530a367336d03",
-          "sizeInByte": 4361000,
-          "version": "1.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Spectacle",
-    "id": "2de49589933c27cb427856dffe408881c7f4f7e243d87041d98530a367336d03",
     "name": "spectacle",
   },
   Object {
@@ -1387,22 +667,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:epson scanner",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "EPSON Scanner",
-          "id": "c6b28eeb69c78f3db1ca1477dc18b4053dab91f394f03f39464404af8266558a",
-          "sizeInByte": 24266633,
-          "version": "5.7.24",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "EPSON Scanner",
-    "id": "c6b28eeb69c78f3db1ca1477dc18b4053dab91f394f03f39464404af8266558a",
     "name": "epson scanner",
   },
   Object {
@@ -1410,22 +678,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:canon ijscanner2",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Canon IJScanner2",
-          "id": "fa1e45e22b6d42487864dd0654c218985a01bbfc3eb604e2ffe89a6f698bb09b",
-          "sizeInByte": 423023,
-          "version": "4.0.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Canon IJScanner2",
-    "id": "fa1e45e22b6d42487864dd0654c218985a01bbfc3eb604e2ffe89a6f698bb09b",
     "name": "canon ijscanner2",
   },
   Object {
@@ -1433,22 +689,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:canon ijscanner6",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Canon IJScanner6",
-          "id": "b092d4a21d3742fed5e1fde0a6b2124fa5adb70370d07a72cd95398ca56fe5f1",
-          "sizeInByte": 401098,
-          "version": "4.0.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Canon IJScanner6",
-    "id": "b092d4a21d3742fed5e1fde0a6b2124fa5adb70370d07a72cd95398ca56fe5f1",
     "name": "canon ijscanner6",
   },
   Object {
@@ -1456,22 +700,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:canon ijscanner4",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Canon IJScanner4",
-          "id": "be911d03c244d43d1995c7ef7871ea74a0ce930bd059640c1aa22e392036f64b",
-          "sizeInByte": 392882,
-          "version": "4.0.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Canon IJScanner4",
-    "id": "be911d03c244d43d1995c7ef7871ea74a0ce930bd059640c1aa22e392036f64b",
     "name": "canon ijscanner4",
   },
   Object {
@@ -1479,22 +711,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:profilehelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ProfileHelper",
-          "id": "369821864b74fb26eb4fe1835720f1f1dc2e31c9ec2fc8ec9e7d80d347f2f920",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ProfileHelper",
-    "id": "369821864b74fb26eb4fe1835720f1f1dc2e31c9ec2fc8ec9e7d80d347f2f920",
     "name": "profilehelper",
   },
   Object {
@@ -1502,22 +722,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:system preferences",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "System Preferences",
-          "id": "5aea2680671006cab16ef45661937cca6d440371007b431ae15fc628086e6dad",
-          "sizeInByte": 1,
-          "version": "14.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "System Preferences",
-    "id": "5aea2680671006cab16ef45661937cca6d440371007b431ae15fc628086e6dad",
     "name": "system preferences",
   },
   Object {
@@ -1525,22 +733,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:installer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Installer",
-          "id": "3e42650e9545e5317ea4e005c2cce264e237f82cd616e5addbb6287e3edc9dce",
-          "sizeInByte": 1,
-          "version": "6.2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Installer",
-    "id": "3e42650e9545e5317ea4e005c2cce264e237f82cd616e5addbb6287e3edc9dce",
     "name": "installer",
   },
   Object {
@@ -1548,22 +744,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:messages",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Messages",
-          "id": "3a2e8d647df618a590277fb93bd9791082af0ee7e6facd338511eb8051748183",
-          "sizeInByte": 1,
-          "version": "14.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Messages",
-    "id": "3a2e8d647df618a590277fb93bd9791082af0ee7e6facd338511eb8051748183",
     "name": "messages",
   },
   Object {
@@ -1571,22 +755,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:diskimagemounter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "DiskImageMounter",
-          "id": "85baa2d6e11b07361350d8578b4b4869f254b84c821eddd3bc326c3813e0a281",
-          "sizeInByte": 1,
-          "version": "595.40.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "DiskImageMounter",
-    "id": "85baa2d6e11b07361350d8578b4b4869f254b84c821eddd3bc326c3813e0a281",
     "name": "diskimagemounter",
   },
   Object {
@@ -1594,22 +766,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:summary service",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Summary Service",
-          "id": "77cfede81eac81d0a624bc7d8375755565331ecf3be4bb1331660b99b7019351",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Summary Service",
-    "id": "77cfede81eac81d0a624bc7d8375755565331ecf3be4bb1331660b99b7019351",
     "name": "summary service",
   },
   Object {
@@ -1617,22 +777,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:universalaccessauthwarn",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "universalAccessAuthWarn",
-          "id": "bc689d9dd99f4a8145482b4ccc7360bde20d54bb0e243dc14d8e4f3f2ca0d7a4",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "universalAccessAuthWarn",
-    "id": "bc689d9dd99f4a8145482b4ccc7360bde20d54bb0e243dc14d8e4f3f2ca0d7a4",
     "name": "universalaccessauthwarn",
   },
   Object {
@@ -1640,22 +788,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:universalaccesshud",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "UniversalAccessHUD",
-          "id": "f89faf15939ea4c31a67c45a788d4c2a3cc6d3868c1e86d3bf2d054625f91058",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "UniversalAccessHUD",
-    "id": "f89faf15939ea4c31a67c45a788d4c2a3cc6d3868c1e86d3bf2d054625f91058",
     "name": "universalaccesshud",
   },
   Object {
@@ -1663,22 +799,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:axvisualsupportagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AXVisualSupportAgent",
-          "id": "ac9bdbe226c7aab8b89d44dfc67dd9ff8cde0d3cdd9ae5a176be33b9d40d5896",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AXVisualSupportAgent",
-    "id": "ac9bdbe226c7aab8b89d44dfc67dd9ff8cde0d3cdd9ae5a176be33b9d40d5896",
     "name": "axvisualsupportagent",
   },
   Object {
@@ -1686,22 +810,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:syncuid",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "syncuid",
-          "id": "ebac3ab17ca864cbaabd813dfd83326cf07d05a12607e1d3c005ea98ada64fbf",
-          "sizeInByte": 1,
-          "version": "8.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "syncuid",
-    "id": "ebac3ab17ca864cbaabd813dfd83326cf07d05a12607e1d3c005ea98ada64fbf",
     "name": "syncuid",
   },
   Object {
@@ -1709,22 +821,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:conflict resolver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Conflict Resolver",
-          "id": "47fce4b9df8f6156d9ce7f4fc35d49665c0c396906a915a44c00518cf3ec5aa9",
-          "sizeInByte": 1,
-          "version": "8.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Conflict Resolver",
-    "id": "47fce4b9df8f6156d9ce7f4fc35d49665c0c396906a915a44c00518cf3ec5aa9",
     "name": "conflict resolver",
   },
   Object {
@@ -1732,22 +832,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:stmuihelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "STMUIHelper",
-          "id": "1182f4b2eeb460fece2c22d80c3011ce0786536785d1b28d359be8b5c3befea8",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "STMUIHelper",
-    "id": "1182f4b2eeb460fece2c22d80c3011ce0786536785d1b28d359be8b5c3befea8",
     "name": "stmuihelper",
   },
   Object {
@@ -1755,22 +843,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:speech downloader",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Speech Downloader",
-          "id": "857f5a5d65c5dc4790dd9865839e6fc86a4fe332d3d9d9eb4f3d123896a8f2ee",
-          "sizeInByte": 1,
-          "version": "9.0.30",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Speech Downloader",
-    "id": "857f5a5d65c5dc4790dd9865839e6fc86a4fe332d3d9d9eb4f3d123896a8f2ee",
     "name": "speech downloader",
   },
   Object {
@@ -1778,22 +854,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:softwareupdatenotificationmanager",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SoftwareUpdateNotificationManager",
-          "id": "513a2e8b6121cf3c74bc469da1c34c81e48efb4f48137da597da78d983499f54",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SoftwareUpdateNotificationManager",
-    "id": "513a2e8b6121cf3c74bc469da1c34c81e48efb4f48137da597da78d983499f54",
     "name": "softwareupdatenotificationmanager",
   },
   Object {
@@ -1801,22 +865,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:voiceover quickstart",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VoiceOver Quickstart",
-          "id": "a56fbcb9b71b4d05bcec6c981124dd7a321ca6eb797a2f9131adc9601d84e814",
-          "sizeInByte": 1,
-          "version": "10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VoiceOver Quickstart",
-    "id": "a56fbcb9b71b4d05bcec6c981124dd7a321ca6eb797a2f9131adc9601d84e814",
     "name": "voiceover quickstart",
   },
   Object {
@@ -1824,22 +876,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:speechsynthesizerauditor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SpeechSynthesizerAuditor",
-          "id": "48ea2c17c15fec7b1db30338a3dd29192522138624ad0574a949328408186cc6",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SpeechSynthesizerAuditor",
-    "id": "48ea2c17c15fec7b1db30338a3dd29192522138624ad0574a949328408186cc6",
     "name": "speechsynthesizerauditor",
   },
   Object {
@@ -1847,22 +887,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:screenreaderuiserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ScreenReaderUIServer",
-          "id": "9b1731ee69dcef2045dfd3f18097e5b1f14ad41de4cfc0854874ddb6da915095",
-          "sizeInByte": 1,
-          "version": "10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ScreenReaderUIServer",
-    "id": "9b1731ee69dcef2045dfd3f18097e5b1f14ad41de4cfc0854874ddb6da915095",
     "name": "screenreaderuiserver",
   },
   Object {
@@ -1870,22 +898,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:nbagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "nbagent",
-          "id": "20c3faac26e82e93c2a6722042678bff0bfe041cf5ee0f76f44f6fbe8906f236",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "nbagent",
-    "id": "20c3faac26e82e93c2a6722042678bff0bfe041cf5ee0f76f44f6fbe8906f236",
     "name": "nbagent",
   },
   Object {
@@ -1893,22 +909,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:identityservicesd",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "identityservicesd",
-          "id": "253fd89b8ede0b6e957cfecd5b5cfa08de339bc5d353b8019b87af4c10481c84",
-          "sizeInByte": 1,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "identityservicesd",
-    "id": "253fd89b8ede0b6e957cfecd5b5cfa08de339bc5d353b8019b87af4c10481c84",
     "name": "identityservicesd",
   },
   Object {
@@ -1916,22 +920,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:findmymacmessenger",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FindMyMacMessenger",
-          "id": "8bcc18c1c51b4eaebd3e5eedd9645278ee259ad802bd8f94eec8c47dc9c12a9c",
-          "sizeInByte": 1,
-          "version": "4.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FindMyMacMessenger",
-    "id": "8bcc18c1c51b4eaebd3e5eedd9645278ee259ad802bd8f94eec8c47dc9c12a9c",
     "name": "findmymacmessenger",
   },
   Object {
@@ -1939,22 +931,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:family (osx)",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Family (OSX)",
-          "id": "bed469fda85a1d19bc02ee636802cf3f097d314b72906bfea3dcfc3a76ec7e2b",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Family (OSX)",
-    "id": "bed469fda85a1d19bc02ee636802cf3f097d314b72906bfea3dcfc3a76ec7e2b",
     "name": "family (osx)",
   },
   Object {
@@ -1962,22 +942,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:parentalcontrols",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ParentalControls",
-          "id": "ffcac36ebc8e94798b7b4f3f7a8671f95fe3b2bde57ba09b0219c894189acbc6",
-          "sizeInByte": 1,
-          "version": "4.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ParentalControls",
-    "id": "ffcac36ebc8e94798b7b4f3f7a8671f95fe3b2bde57ba09b0219c894189acbc6",
     "name": "parentalcontrols",
   },
   Object {
@@ -1985,22 +953,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:eaptlstrust",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "eaptlstrust",
-          "id": "620782c2852fab41debc1d1c0f167f35ccb59124cb6795214e7adbd077247f27",
-          "sizeInByte": 1,
-          "version": "13.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "eaptlstrust",
-    "id": "620782c2852fab41debc1d1c0f167f35ccb59124cb6795214e7adbd077247f27",
     "name": "eaptlstrust",
   },
   Object {
@@ -2008,22 +964,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:diskimages ui agent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "DiskImages UI Agent",
-          "id": "a14003015dcc5fe7bfebe102297d0639388f3bf800f2be4360b6317156a90fb3",
-          "sizeInByte": 1,
-          "version": "595.40.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "DiskImages UI Agent",
-    "id": "a14003015dcc5fe7bfebe102297d0639388f3bf800f2be4360b6317156a90fb3",
     "name": "diskimages ui agent",
   },
   Object {
@@ -2031,22 +975,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:followupui",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FollowUpUI",
-          "id": "58cdd380e2250613b33444aa06489b110f19d643ed7348684ca33d2c966e7913",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FollowUpUI",
-    "id": "58cdd380e2250613b33444aa06489b110f19d643ed7348684ca33d2c966e7913",
     "name": "followupui",
   },
   Object {
@@ -2054,22 +986,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:cimfindinputcodetool",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "CIMFindInputCodeTool",
-          "id": "40b06e036d139d0158ab5e0b22d7fc1ca70e61429d02e473b762a644bf04114f",
-          "sizeInByte": 1,
-          "version": "104",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "CIMFindInputCodeTool",
-    "id": "40b06e036d139d0158ab5e0b22d7fc1ca70e61429d02e473b762a644bf04114f",
     "name": "cimfindinputcodetool",
   },
   Object {
@@ -2077,22 +997,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:storeuid",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "storeuid",
-          "id": "81d982660229aafdb3fdc4da83720c23c7c141089bbab15184073cc2e5028f8f",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "storeuid",
-    "id": "81d982660229aafdb3fdc4da83720c23c7c141089bbab15184073cc2e5028f8f",
     "name": "storeuid",
   },
   Object {
@@ -2100,22 +1008,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:askpermissionui",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AskPermissionUI",
-          "id": "b737629ef456b5bc8ddbe1a642c03b2133c909af67d7910488f0c0cb65e9bb87",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AskPermissionUI",
-    "id": "b737629ef456b5bc8ddbe1a642c03b2133c909af67d7910488f0c0cb65e9bb87",
     "name": "askpermissionui",
   },
   Object {
@@ -2123,22 +1019,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:kerberosmenuextra",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "KerberosMenuExtra",
-          "id": "e1e37814753ec1d2e93f8bc54ce53092bdae44b1b702cf8dfceec3fbd89f362a",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "KerberosMenuExtra",
-    "id": "e1e37814753ec1d2e93f8bc54ce53092bdae44b1b702cf8dfceec3fbd89f362a",
     "name": "kerberosmenuextra",
   },
   Object {
@@ -2146,22 +1030,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:appssoagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AppSSOAgent",
-          "id": "3608e5bcc30a09a7990d92edb922e4385a2cd4992a5a4aba095d28dca0d54cba",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AppSSOAgent",
-    "id": "3608e5bcc30a09a7990d92edb922e4385a2cd4992a5a4aba095d28dca0d54cba",
     "name": "appssoagent",
   },
   Object {
@@ -2169,22 +1041,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:calibration assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Calibration Assistant",
-          "id": "a12218271eacf3c22af1a11ab747a31d6a09bd9a1aa870b520f27203df782b2d",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Calibration Assistant",
-    "id": "a12218271eacf3c22af1a11ab747a31d6a09bd9a1aa870b520f27203df782b2d",
     "name": "calibration assistant",
   },
   Object {
@@ -2192,22 +1052,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:aospushrelay",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AOSPushRelay",
-          "id": "7c1e28ece1bdfe29811d5433326b8173372a8d2015385909abe8815fd19ce67a",
-          "sizeInByte": 1,
-          "version": "1.07",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AOSPushRelay",
-    "id": "7c1e28ece1bdfe29811d5433326b8173372a8d2015385909abe8815fd19ce67a",
     "name": "aospushrelay",
   },
   Object {
@@ -2215,22 +1063,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:aosheartbeat",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AOSHeartbeat",
-          "id": "ea63337cb44318eb31844b88dd52ade5915294274e9d4fd6ceaf71a2e5fbf2d4",
-          "sizeInByte": 1,
-          "version": "1.07",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AOSHeartbeat",
-    "id": "ea63337cb44318eb31844b88dd52ade5915294274e9d4fd6ceaf71a2e5fbf2d4",
     "name": "aosheartbeat",
   },
   Object {
@@ -2238,22 +1074,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:icloudusernotificationsd",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "iCloudUserNotificationsd",
-          "id": "138a9c5ad8e734ff2de0801273b4fe70d3b936ac68c0841f833c22ef438f1889",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "iCloudUserNotificationsd",
-    "id": "138a9c5ad8e734ff2de0801273b4fe70d3b936ac68c0841f833c22ef438f1889",
     "name": "icloudusernotificationsd",
   },
   Object {
@@ -2261,22 +1085,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:vietnameseim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VietnameseIM",
-          "id": "33e3c881a782351fed0cfc9be3f3953205245190f137534aab761cfdea896432",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VietnameseIM",
-    "id": "33e3c881a782351fed0cfc9be3f3953205245190f137534aab761cfdea896432",
     "name": "vietnameseim",
   },
   Object {
@@ -2284,22 +1096,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:trackpadim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TrackpadIM",
-          "id": "18ac9e68230e67bf646c887b65b4f6d3fc81dd221d2a90a9e73f22fef2b907f5",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TrackpadIM",
-    "id": "18ac9e68230e67bf646c887b65b4f6d3fc81dd221d2a90a9e73f22fef2b907f5",
     "name": "trackpadim",
   },
   Object {
@@ -2307,22 +1107,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:tyim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TYIM",
-          "id": "514a93dd70c53231c8f30c7f9b95111d0673d76f36183a07dd4b06fad148bf06",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TYIM",
-    "id": "514a93dd70c53231c8f30c7f9b95111d0673d76f36183a07dd4b06fad148bf06",
     "name": "tyim",
   },
   Object {
@@ -2330,22 +1118,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:tcim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TCIM",
-          "id": "44fb13ccab097b9602a8698b8279671e39e56ac4cb82cf6919517aaa676c9b46",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TCIM",
-    "id": "44fb13ccab097b9602a8698b8279671e39e56ac4cb82cf6919517aaa676c9b46",
     "name": "tcim",
   },
   Object {
@@ -2353,22 +1129,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:scim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SCIM",
-          "id": "d1c74be60660b53100951678f59e2bf645cb3feaf55b66bcb54eed41628c1de1",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SCIM",
-    "id": "d1c74be60660b53100951678f59e2bf645cb3feaf55b66bcb54eed41628c1de1",
     "name": "scim",
   },
   Object {
@@ -2376,22 +1140,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pressandhold",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PressAndHold",
-          "id": "ab600dbe1de76379730ba8e4eddd74a058472158bd5b8cc344ca9c7a380b9dbe",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PressAndHold",
-    "id": "ab600dbe1de76379730ba8e4eddd74a058472158bd5b8cc344ca9c7a380b9dbe",
     "name": "pressandhold",
   },
   Object {
@@ -2399,22 +1151,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pluginim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PluginIM",
-          "id": "a821d03ceda5997f4bcf040259eb6bbe9beda8d888f32f5cb5466e36647b8083",
-          "sizeInByte": 1,
-          "version": "24",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PluginIM",
-    "id": "a821d03ceda5997f4bcf040259eb6bbe9beda8d888f32f5cb5466e36647b8083",
     "name": "pluginim",
   },
   Object {
@@ -2422,22 +1162,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:koreanim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "KoreanIM",
-          "id": "c0a81789e5b51515ca1c7bccefaefb3f546a90caafe8fed22c6a09b8ed121eec",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "KoreanIM",
-    "id": "c0a81789e5b51515ca1c7bccefaefb3f546a90caafe8fed22c6a09b8ed121eec",
     "name": "koreanim",
   },
   Object {
@@ -2445,22 +1173,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:japaneseim-romajityping",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "JapaneseIM-RomajiTyping",
-          "id": "e02781111c9432012dfecb630fe12cb975f3c67b61dd57c3991c88014f2d0e65",
-          "sizeInByte": 1,
-          "version": "6.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "JapaneseIM-RomajiTyping",
-    "id": "e02781111c9432012dfecb630fe12cb975f3c67b61dd57c3991c88014f2d0e65",
     "name": "japaneseim-romajityping",
   },
   Object {
@@ -2468,22 +1184,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:japaneseim-kanatyping",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "JapaneseIM-KanaTyping",
-          "id": "19db9018062c74bdc82b40e7d95dbf3fa48eaab2f31b8acd214a34258fe50afc",
-          "sizeInByte": 1,
-          "version": "6.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "JapaneseIM-KanaTyping",
-    "id": "19db9018062c74bdc82b40e7d95dbf3fa48eaab2f31b8acd214a34258fe50afc",
     "name": "japaneseim-kanatyping",
   },
   Object {
@@ -2491,22 +1195,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:hindiim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "HindiIM",
-          "id": "e82e86505eef51e602b1fcc64aca5342f24fcb14a22c2b20ad8a553fbf7dbf06",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "HindiIM",
-    "id": "e82e86505eef51e602b1fcc64aca5342f24fcb14a22c2b20ad8a553fbf7dbf06",
     "name": "hindiim",
   },
   Object {
@@ -2514,22 +1206,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:emojifunctionrowim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "EmojiFunctionRowIM",
-          "id": "a9c79b583a959c63d108d5b35973c634e103b47e6321225b3a81200c54217216",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "EmojiFunctionRowIM",
-    "id": "a9c79b583a959c63d108d5b35973c634e103b47e6321225b3a81200c54217216",
     "name": "emojifunctionrowim",
   },
   Object {
@@ -2537,22 +1217,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dictation",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Dictation",
-          "id": "a059396ab78f9d03a21ec8762bf2c12f257654008c4d38c4a9efde8c527fb6c1",
-          "sizeInByte": 1,
-          "version": "6.0.87.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Dictation",
-    "id": "a059396ab78f9d03a21ec8762bf2c12f257654008c4d38c4a9efde8c527fb6c1",
     "name": "dictation",
   },
   Object {
@@ -2560,22 +1228,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:characterpalette",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "CharacterPalette",
-          "id": "706f806f8dbd07d220ae77069b4d4b0e433920312951f881856997f73311484a",
-          "sizeInByte": 1,
-          "version": "2.0.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "CharacterPalette",
-    "id": "706f806f8dbd07d220ae77069b4d4b0e433920312951f881856997f73311484a",
     "name": "characterpalette",
   },
   Object {
@@ -2583,22 +1239,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:assistive control",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Assistive Control",
-          "id": "5070baf1ce4e927c28d66fd7168dc529666cec0cdd7b11e1bbd9d2095268da43",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Assistive Control",
-    "id": "5070baf1ce4e927c28d66fd7168dc529666cec0cdd7b11e1bbd9d2095268da43",
     "name": "assistive control",
   },
   Object {
@@ -2606,22 +1250,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ptpcamera",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PTPCamera",
-          "id": "63d93d025183a62e38cbcec5ea32a78d2afdd6b009c9969b005259c8f5f08d17",
-          "sizeInByte": 1,
-          "version": "1708.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PTPCamera",
-    "id": "63d93d025183a62e38cbcec5ea32a78d2afdd6b009c9969b005259c8f5f08d17",
     "name": "ptpcamera",
   },
   Object {
@@ -2629,22 +1261,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:airscanscanner",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AirScanScanner",
-          "id": "20561da5eb6bead9ec824483a8e39a04e4334882a708841d00497eec37014e37",
-          "sizeInByte": 1,
-          "version": "16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AirScanScanner",
-    "id": "20561da5eb6bead9ec824483a8e39a04e4334882a708841d00497eec37014e37",
     "name": "airscanscanner",
   },
   Object {
@@ -2652,22 +1272,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:makepdf",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MakePDF",
-          "id": "f1d48255fc65ab708345e1bc507cebb479e7e0803dc8a4d784c55539a3b6775c",
-          "sizeInByte": 1,
-          "version": "10.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MakePDF",
-    "id": "f1d48255fc65ab708345e1bc507cebb479e7e0803dc8a4d784c55539a3b6775c",
     "name": "makepdf",
   },
   Object {
@@ -2675,22 +1283,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:build web page",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Build Web Page",
-          "id": "2fab3d8caddf857f3bf2a865c2b6ba73f27984b91e1ea55156d39ca51a77c004",
-          "sizeInByte": 1,
-          "version": "10.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Build Web Page",
-    "id": "2fab3d8caddf857f3bf2a865c2b6ba73f27984b91e1ea55156d39ca51a77c004",
     "name": "build web page",
   },
   Object {
@@ -2698,22 +1294,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:quick look simulator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Quick Look Simulator",
-          "id": "7c529f3d67c524ef3727b34e1bcc642bfd23d94454251aa14308b98e16472a2b",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Quick Look Simulator",
-    "id": "7c529f3d67c524ef3727b34e1bcc642bfd23d94454251aa14308b98e16472a2b",
     "name": "quick look simulator",
   },
   Object {
@@ -2721,22 +1305,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:smartcard pairing",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SmartCard Pairing",
-          "id": "89203db88cc9a7114cc0f8da74c60ab7035a12b6865c596bebe7606268c866dd",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SmartCard Pairing",
-    "id": "89203db88cc9a7114cc0f8da74c60ab7035a12b6865c596bebe7606268c866dd",
     "name": "smartcard pairing",
   },
   Object {
@@ -2744,22 +1316,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:printerproxy",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PrinterProxy",
-          "id": "71d83d989379db5fd5e39007c58c71a6e9db42eb1ab6eb7d32d710aef88699fa",
-          "sizeInByte": 1,
-          "version": "16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PrinterProxy",
-    "id": "71d83d989379db5fd5e39007c58c71a6e9db42eb1ab6eb7d32d710aef88699fa",
     "name": "printerproxy",
   },
   Object {
@@ -2767,22 +1327,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:fontregistryuiagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FontRegistryUIAgent",
-          "id": "517176edb9c1317454acdb783a18b07736cb52716f0ff95ebdb2c4da1a3c8876",
-          "sizeInByte": 1,
-          "version": "81.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FontRegistryUIAgent",
-    "id": "517176edb9c1317454acdb783a18b07736cb52716f0ff95ebdb2c4da1a3c8876",
     "name": "fontregistryuiagent",
   },
   Object {
@@ -2790,22 +1338,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:abassistantservice",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ABAssistantService",
-          "id": "59af5b8faa726b2725ade090ecc02e2afe24392e6450bdfab985f244769c21cb",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ABAssistantService",
-    "id": "59af5b8faa726b2725ade090ecc02e2afe24392e6450bdfab985f244769c21cb",
     "name": "abassistantservice",
   },
   Object {
@@ -2813,22 +1349,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:addressbooksync",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AddressBookSync",
-          "id": "8ffb10233158c2b8424a26aa5aab84fcaefaf2287a27fd5fcf4bb0df13c23ddb",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AddressBookSync",
-    "id": "8ffb10233158c2b8424a26aa5aab84fcaefaf2287a27fd5fcf4bb0df13c23ddb",
     "name": "addressbooksync",
   },
   Object {
@@ -2836,22 +1360,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:screencaptureui",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "screencaptureui",
-          "id": "6f9dcf0b898e8a8551d5cf839b9eb272a307d84c98920ff8f388ddc6a6c3e449",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "screencaptureui",
-    "id": "6f9dcf0b898e8a8551d5cf839b9eb272a307d84c98920ff8f388ddc6a6c3e449",
     "name": "screencaptureui",
   },
   Object {
@@ -2859,22 +1371,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:loginwindow",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "loginwindow",
-          "id": "ee4c745a03633fecff69cd85887e75e9a593e4e7e0b2abbfc4dd42bf3570680d",
-          "sizeInByte": 1,
-          "version": "9.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "loginwindow",
-    "id": "ee4c745a03633fecff69cd85887e75e9a593e4e7e0b2abbfc4dd42bf3570680d",
     "name": "loginwindow",
   },
   Object {
@@ -2882,22 +1382,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:icloud",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "iCloud",
-          "id": "7a1dbe729134cc43fc385de7a7cb2ef93b1e4b0634ee1e4d6e770ea49f2e99f4",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "iCloud",
-    "id": "7a1dbe729134cc43fc385de7a7cb2ef93b1e4b0634ee1e4d6e770ea49f2e99f4",
     "name": "icloud",
   },
   Object {
@@ -2905,22 +1393,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:widgetkit simulator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "WidgetKit Simulator",
-          "id": "b4b6c6c28bad467476d826f43f3e52c8823b342051ccb541218ff37c515b3679",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "WidgetKit Simulator",
-    "id": "b4b6c6c28bad467476d826f43f3e52c8823b342051ccb541218ff37c515b3679",
     "name": "widgetkit simulator",
   },
   Object {
@@ -2928,22 +1404,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:wifiagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "WiFiAgent",
-          "id": "90d662370f84dca305183b6e49c7ae7cb098d1989be3653b87c0dcfd8b682165",
-          "sizeInByte": 1,
-          "version": "17.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "WiFiAgent",
-    "id": "90d662370f84dca305183b6e49c7ae7cb098d1989be3653b87c0dcfd8b682165",
     "name": "wifiagent",
   },
   Object {
@@ -2951,22 +1415,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:watch face help",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Watch Face Help",
-          "id": "5e3485c7115c82214b089563e7baaadd3c13324403a7590ad86ef71a3abd592d",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Watch Face Help",
-    "id": "5e3485c7115c82214b089563e7baaadd3c13324403a7590ad86ef71a3abd592d",
     "name": "watch face help",
   },
   Object {
@@ -2974,22 +1426,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:unmountassistantagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "UnmountAssistantAgent",
-          "id": "2834d09810307a68f226191f0b8d2878d858f9d501a2f0e3c703eaeab042d00e",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "UnmountAssistantAgent",
-    "id": "2834d09810307a68f226191f0b8d2878d858f9d501a2f0e3c703eaeab042d00e",
     "name": "unmountassistantagent",
   },
   Object {
@@ -2997,22 +1437,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:universalaccesscontrol",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "UniversalAccessControl",
-          "id": "959161579f030e2879b2866041a08940ba46cd0781e267abf1ac648acd30ccc4",
-          "sizeInByte": 1,
-          "version": "7.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "UniversalAccessControl",
-    "id": "959161579f030e2879b2866041a08940ba46cd0781e267abf1ac648acd30ccc4",
     "name": "universalaccesscontrol",
   },
   Object {
@@ -3020,22 +1448,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:thermaltrap",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ThermalTrap",
-          "id": "756990b750d05329af60285479f9165542186a281041176d1e254b59da89a94e",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ThermalTrap",
-    "id": "756990b750d05329af60285479f9165542186a281041176d1e254b59da89a94e",
     "name": "thermaltrap",
   },
   Object {
@@ -3043,22 +1459,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:systemuiserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SystemUIServer",
-          "id": "d9802a67216c63f9155c858d6ec70e017794b348fc205fb3d95b608b6487296f",
-          "sizeInByte": 1,
-          "version": "1.7",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SystemUIServer",
-    "id": "d9802a67216c63f9155c858d6ec70e017794b348fc205fb3d95b608b6487296f",
     "name": "systemuiserver",
   },
   Object {
@@ -3066,22 +1470,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:system events",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "System Events",
-          "id": "fa030251247f984794d72b02d60fc54d8026b783b89f3cb864b1513d792ffdf3",
-          "sizeInByte": 1,
-          "version": "1.3.6",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "System Events",
-    "id": "fa030251247f984794d72b02d60fc54d8026b783b89f3cb864b1513d792ffdf3",
     "name": "system events",
   },
   Object {
@@ -3089,22 +1481,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:spotlight",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Spotlight",
-          "id": "51364c548118cbd128c51098dc68b0a30aeb9bc72e491ea0dd5751576f5bbc7e",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Spotlight",
-    "id": "51364c548118cbd128c51098dc68b0a30aeb9bc72e491ea0dd5751576f5bbc7e",
     "name": "spotlight",
   },
   Object {
@@ -3112,22 +1492,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:software update",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Software Update",
-          "id": "9b11c978c182d8fdaa17a59ab945bb37bb1083e91c635f3835f66b77932e9317",
-          "sizeInByte": 1,
-          "version": "6",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Software Update",
-    "id": "9b11c978c182d8fdaa17a59ab945bb37bb1083e91c635f3835f66b77932e9317",
     "name": "software update",
   },
   Object {
@@ -3135,22 +1503,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:siri",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Siri",
-          "id": "dca4415e0336e502679dff7fc351c66738d66b3bdeb9642f63cf6279e27ddca3",
-          "sizeInByte": 1,
-          "version": "201.3.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Siri",
-    "id": "dca4415e0336e502679dff7fc351c66738d66b3bdeb9642f63cf6279e27ddca3",
     "name": "siri",
   },
   Object {
@@ -3158,22 +1514,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:setup assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Setup Assistant",
-          "id": "730224cdfb2b24218edd148f2a305ce598254ea1253ada5fd62e6e83acbae432",
-          "sizeInByte": 1,
-          "version": "10.10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Setup Assistant",
-    "id": "730224cdfb2b24218edd148f2a305ce598254ea1253ada5fd62e6e83acbae432",
     "name": "setup assistant",
   },
   Object {
@@ -3181,22 +1525,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:screen time",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Screen Time",
-          "id": "85ed983781265e456a42f92c619ea8bf09219db3d0c1e898b8cf1184f6c0c0ba",
-          "sizeInByte": 1,
-          "version": "3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Screen Time",
-    "id": "85ed983781265e456a42f92c619ea8bf09219db3d0c1e898b8cf1184f6c0c0ba",
     "name": "screen time",
   },
   Object {
@@ -3204,22 +1536,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ssmenuagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SSMenuAgent",
-          "id": "4f66b542589b1d1619d72b7a1a51a7554266959e39061184a6e8517cf5701548",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SSMenuAgent",
-    "id": "4f66b542589b1d1619d72b7a1a51a7554266959e39061184a6e8517cf5701548",
     "name": "ssmenuagent",
   },
   Object {
@@ -3227,22 +1547,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ardagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ARDAgent",
-          "id": "f46144d97a9f6af433da091fc516c41ba5717bed6ab832a960297b4976e9dbad",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ARDAgent",
-    "id": "f46144d97a9f6af433da091fc516c41ba5717bed6ab832a960297b4976e9dbad",
     "name": "ardagent",
   },
   Object {
@@ -3250,22 +1558,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:problem reporter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Problem Reporter",
-          "id": "afaf3ad57450b9377c3996e81d2cd232206fe1c3f4fa6e3e9d74c62ec6e3109a",
-          "sizeInByte": 1,
-          "version": "10.13",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Problem Reporter",
-    "id": "afaf3ad57450b9377c3996e81d2cd232206fe1c3f4fa6e3e9d74c62ec6e3109a",
     "name": "problem reporter",
   },
   Object {
@@ -3273,22 +1569,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:podcastsauthagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PodcastsAuthAgent",
-          "id": "0c7dc4b1f9f23312e2a1fb697121ca4a83f1a502bcdce77c9e8814a66352c753",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PodcastsAuthAgent",
-    "id": "0c7dc4b1f9f23312e2a1fb697121ca4a83f1a502bcdce77c9e8814a66352c753",
     "name": "podcastsauthagent",
   },
   Object {
@@ -3296,22 +1580,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:photo library migration utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Photo Library Migration Utility",
-          "id": "fe6105a37d9081c26740cd2326365e27181ae6d93d08a6d348d20efc6ffb92c5",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Photo Library Migration Utility",
-    "id": "fe6105a37d9081c26740cd2326365e27181ae6d93d08a6d348d20efc6ffb92c5",
     "name": "photo library migration utility",
   },
   Object {
@@ -3319,22 +1591,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:obexagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OBEXAgent",
-          "id": "eb271e4c7cc1c3e25ab7fe14c6a2fbe2ef994c1cb400b9008efe7dc4aa6feefe",
-          "sizeInByte": 1,
-          "version": "8.0.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OBEXAgent",
-    "id": "eb271e4c7cc1c3e25ab7fe14c6a2fbe2ef994c1cb400b9008efe7dc4aa6feefe",
     "name": "obexagent",
   },
   Object {
@@ -3342,22 +1602,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:notification center",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Notification Center",
-          "id": "3628b9f795dd96942505f4cbf8fb21a541d0c465013c975f40f6fd4d9f779923",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Notification Center",
-    "id": "3628b9f795dd96942505f4cbf8fb21a541d0c465013c975f40f6fd4d9f779923",
     "name": "notification center",
   },
   Object {
@@ -3365,22 +1613,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:netauthagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "NetAuthAgent",
-          "id": "b6050dda708affefc052daf47ea321b534c8d3b162d96686939e86086c502c04",
-          "sizeInByte": 1,
-          "version": "6.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "NetAuthAgent",
-    "id": "b6050dda708affefc052daf47ea321b534c8d3b162d96686939e86086c502c04",
     "name": "netauthagent",
   },
   Object {
@@ -3388,22 +1624,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:managedclient",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ManagedClient",
-          "id": "0a73fd5b05fcc10ca114341171dc86945c44b4d4fe2df32188204e2ab1df1679",
-          "sizeInByte": 1,
-          "version": "13.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ManagedClient",
-    "id": "0a73fd5b05fcc10ca114341171dc86945c44b4d4fe2df32188204e2ab1df1679",
     "name": "managedclient",
   },
   Object {
@@ -3411,22 +1635,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:language chooser",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Language Chooser",
-          "id": "e3d1991619a8178bd051ecd6ce2bafedb0c647db17d0e69acc6a228216f9b1ba",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Language Chooser",
-    "id": "e3d1991619a8178bd051ecd6ce2bafedb0c647db17d0e69acc6a228216f9b1ba",
     "name": "language chooser",
   },
   Object {
@@ -3434,22 +1646,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:keychain circle notification",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Keychain Circle Notification",
-          "id": "399ef195de340c9e9b8ce9f6ac44cdf5836fe268a7c964332d0b430996e18723",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Keychain Circle Notification",
-    "id": "399ef195de340c9e9b8ce9f6ac44cdf5836fe268a7c964332d0b430996e18723",
     "name": "keychain circle notification",
   },
   Object {
@@ -3457,22 +1657,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:keyboardsetupassistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "KeyboardSetupAssistant",
-          "id": "a16c9e07f4613e1275a1540b3549b904099228a1d3ae237435ff827c816684a1",
-          "sizeInByte": 1,
-          "version": "10.7",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "KeyboardSetupAssistant",
-    "id": "a16c9e07f4613e1275a1540b3549b904099228a1d3ae237435ff827c816684a1",
     "name": "keyboardsetupassistant",
   },
   Object {
@@ -3480,22 +1668,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:keyboardaccessagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "KeyboardAccessAgent",
-          "id": "ffe6c6e0c2072f13e73b48251b0aa15788aef313c3cc6d185cd5277245d52ac9",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "KeyboardAccessAgent",
-    "id": "ffe6c6e0c2072f13e73b48251b0aa15788aef313c3cc6d185cd5277245d52ac9",
     "name": "keyboardaccessagent",
   },
   Object {
@@ -3503,22 +1679,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:installer progress",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Installer Progress",
-          "id": "dc034855312fb23dc9e7f519d523f509b66feb3e9d7de67bbf6a37db11ff9ad3",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Installer Progress",
-    "id": "dc034855312fb23dc9e7f519d523f509b66feb3e9d7de67bbf6a37db11ff9ad3",
     "name": "installer progress",
   },
   Object {
@@ -3526,22 +1690,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:install in progress",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Install in Progress",
-          "id": "034df70aa3c6c5637c90d512b5b38ac61085f16dc29e361814e8f1f877b959dd",
-          "sizeInByte": 1,
-          "version": "3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Install in Progress",
-    "id": "034df70aa3c6c5637c90d512b5b38ac61085f16dc29e361814e8f1f877b959dd",
     "name": "install in progress",
   },
   Object {
@@ -3549,22 +1701,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:install command line developer tools",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Install Command Line Developer Tools",
-          "id": "36eb4651bc51dcdbf2a8b7418beb604cb56498fc32b8ff3515337d5a1350cba9",
-          "sizeInByte": 1,
-          "version": "2384",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Install Command Line Developer Tools",
-    "id": "36eb4651bc51dcdbf2a8b7418beb604cb56498fc32b8ff3515337d5a1350cba9",
     "name": "install command line developer tools",
   },
   Object {
@@ -3572,22 +1712,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:image events",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Image Events",
-          "id": "ab4453bcb07a6e15fb3ef62081c46d45b3787258d41bf35a89a55eb597c916d3",
-          "sizeInByte": 1,
-          "version": "1.1.6",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Image Events",
-    "id": "ab4453bcb07a6e15fb3ef62081c46d45b3787258d41bf35a89a55eb597c916d3",
     "name": "image events",
   },
   Object {
@@ -3595,22 +1723,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:games",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Games",
-          "id": "cadb403c5f1ebe0d9e96b311dff822c57b90463cfe3d9624ddcff0d8c58e0351",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Games",
-    "id": "cadb403c5f1ebe0d9e96b311dff822c57b90463cfe3d9624ddcff0d8c58e0351",
     "name": "games",
   },
   Object {
@@ -3618,22 +1734,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dock",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Dock",
-          "id": "29b65872c13d2f1b5eb664708185320e939eb67e038bf4893a7472fc04c89534",
-          "sizeInByte": 1,
-          "version": "1.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Dock",
-    "id": "29b65872c13d2f1b5eb664708185320e939eb67e038bf4893a7472fc04c89534",
     "name": "dock",
   },
   Object {
@@ -3641,22 +1745,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:coreservicesuiagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "CoreServicesUIAgent",
-          "id": "2501d5a2b679350fb83cf9b7f8a2652d3762a1cc204aa8195d5476d8b81c6cea",
-          "sizeInByte": 1,
-          "version": "358.5",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "CoreServicesUIAgent",
-    "id": "2501d5a2b679350fb83cf9b7f8a2652d3762a1cc204aa8195d5476d8b81c6cea",
     "name": "coreservicesuiagent",
   },
   Object {
@@ -3664,22 +1756,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:controlstrip",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ControlStrip",
-          "id": "ca02d5eefad35e592b3797fd0a53798af5d84ddc91a2648688648cbf238dd53d",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ControlStrip",
-    "id": "ca02d5eefad35e592b3797fd0a53798af5d84ddc91a2648688648cbf238dd53d",
     "name": "controlstrip",
   },
   Object {
@@ -3687,22 +1767,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:controlcenter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ControlCenter",
-          "id": "b47e1cde4197f8d54828f54529b828ffd0ee107077451b9b36378b7821b7014a",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ControlCenter",
-    "id": "b47e1cde4197f8d54828f54529b828ffd0ee107077451b9b36378b7821b7014a",
     "name": "controlcenter",
   },
   Object {
@@ -3710,22 +1778,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:clock",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Clock",
-          "id": "c9b2dd014361436738aee6b49673694dd0b65d391727fccf122a555f819bf8e2",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Clock",
-    "id": "c9b2dd014361436738aee6b49673694dd0b65d391727fccf122a555f819bf8e2",
     "name": "clock",
   },
   Object {
@@ -3733,22 +1789,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:weather",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Weather",
-          "id": "841432c47b395a4c3f315f8df4a4b3f37eca2885c8366f8b3d264db1a79c5a22",
-          "sizeInByte": 1,
-          "version": "1.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Weather",
-    "id": "841432c47b395a4c3f315f8df4a4b3f37eca2885c8366f8b3d264db1a79c5a22",
     "name": "weather",
   },
   Object {
@@ -3756,22 +1800,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:certificate assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Certificate Assistant",
-          "id": "8a7fd50adcfdba94fd108a28308e1c5ff2a62065205d1ae2761024614b101294",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Certificate Assistant",
-    "id": "8a7fd50adcfdba94fd108a28308e1c5ff2a62065205d1ae2761024614b101294",
     "name": "certificate assistant",
   },
   Object {
@@ -3779,22 +1811,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:captive network assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Captive Network Assistant",
-          "id": "7bf9c3ace30cd14430f958d7c06334ff9ab23066b4c3346942b44ab30adb4bab",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Captive Network Assistant",
-    "id": "7bf9c3ace30cd14430f958d7c06334ff9ab23066b4c3346942b44ab30adb4bab",
     "name": "captive network assistant",
   },
   Object {
@@ -3802,22 +1822,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:bluetoothuiserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "BluetoothUIServer",
-          "id": "edf7d71b968d343dfc6faccd55e7ae2cded07819b564a8ddcee5d14b5b258b88",
-          "sizeInByte": 1,
-          "version": "8.0.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "BluetoothUIServer",
-    "id": "edf7d71b968d343dfc6faccd55e7ae2cded07819b564a8ddcee5d14b5b258b88",
     "name": "bluetoothuiserver",
   },
   Object {
@@ -3825,22 +1833,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:applescript utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AppleScript Utility",
-          "id": "966ea19262748706243832b3048336f19ce22e4937c71a364c6ee1ebcbe4ea8f",
-          "sizeInByte": 1,
-          "version": "1.1.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AppleScript Utility",
-    "id": "966ea19262748706243832b3048336f19ce22e4937c71a364c6ee1ebcbe4ea8f",
     "name": "applescript utility",
   },
   Object {
@@ -3848,22 +1844,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:addprinter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AddPrinter",
-          "id": "a668513af0a239949d37a6500bf6ffe6c5f252fe080dd9a227393473d4d7eb52",
-          "sizeInByte": 1,
-          "version": "16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AddPrinter",
-    "id": "a668513af0a239949d37a6500bf6ffe6c5f252fe080dd9a227393473d4d7eb52",
     "name": "addprinter",
   },
   Object {
@@ -3871,22 +1855,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:avb audio configuration",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AVB Audio Configuration",
-          "id": "201e51381f834281f78d894faedef3a0bb1610680ab4c22e63c1f44aa44df213",
-          "sizeInByte": 1,
-          "version": "930.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AVB Audio Configuration",
-    "id": "201e51381f834281f78d894faedef3a0bb1610680ab4c22e63c1f44aa44df213",
     "name": "avb audio configuration",
   },
   Object {
@@ -3894,22 +1866,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:display calibrator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Display Calibrator",
-          "id": "2e4997bf1c157600343eab32c6ea6f0645224f4f962f7dd8a6059e6a52b2421f",
-          "sizeInByte": 1,
-          "version": "4.12.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Display Calibrator",
-    "id": "2e4997bf1c157600343eab32c6ea6f0645224f4f962f7dd8a6059e6a52b2421f",
     "name": "display calibrator",
   },
   Object {
@@ -3917,22 +1877,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:finder",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Finder",
-          "id": "d2b5d41122e0ecccfd3647983a452ea6e16ed7e3b9ae34fbfe3793abdaed009f",
-          "sizeInByte": 1,
-          "version": "11.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Finder",
-    "id": "d2b5d41122e0ecccfd3647983a452ea6e16ed7e3b9ae34fbfe3793abdaed009f",
     "name": "finder",
   },
   Object {
@@ -3940,22 +1888,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:notes",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Notes",
-          "id": "62d20690a9872cdfd4d9597914a9a819c642a4a12964154ff8e6703aaf6c0d2a",
-          "sizeInByte": 1,
-          "version": "4.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Notes",
-    "id": "62d20690a9872cdfd4d9597914a9a819c642a4a12964154ff8e6703aaf6c0d2a",
     "name": "notes",
   },
   Object {
@@ -3963,22 +1899,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mail",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Mail",
-          "id": "a6d26f752f7cf13810971c4bbc3e1ac46e26bbb03f86b5b2bafd6858695baf50",
-          "sizeInByte": 1,
-          "version": "14.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Mail",
-    "id": "a6d26f752f7cf13810971c4bbc3e1ac46e26bbb03f86b5b2bafd6858695baf50",
     "name": "mail",
   },
   Object {
@@ -3986,22 +1910,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:helpviewer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "HelpViewer",
-          "id": "e79eae9bef4468fe2bb212cfc9648b843388dbfd4d148cbddc0aeefe32c6c170",
-          "sizeInByte": 1,
-          "version": "6.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "HelpViewer",
-    "id": "e79eae9bef4468fe2bb212cfc9648b843388dbfd4d148cbddc0aeefe32c6c170",
     "name": "helpviewer",
   },
   Object {
@@ -4009,22 +1921,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:wireless diagnostics",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Wireless Diagnostics",
-          "id": "cc1dd8b3a0dd888b85035d3a652d4a8ee0cf885c1d8e6841ecb6bad976422fec",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Wireless Diagnostics",
-    "id": "cc1dd8b3a0dd888b85035d3a652d4a8ee0cf885c1d8e6841ecb6bad976422fec",
     "name": "wireless diagnostics",
   },
   Object {
@@ -4032,22 +1932,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:screen sharing",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Screen Sharing",
-          "id": "b5bc9b8f20fa0b590e4bf40b52045850e8c9c36c816b114aa8882346006de967",
-          "sizeInByte": 1,
-          "version": "550.19",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Screen Sharing",
-    "id": "b5bc9b8f20fa0b590e4bf40b52045850e8c9c36c816b114aa8882346006de967",
     "name": "screen sharing",
   },
   Object {
@@ -4055,22 +1943,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:directory utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Directory Utility",
-          "id": "655781cfdfab8c44df923416519b816e39246e4861cca2a72951fad85e1734a0",
-          "sizeInByte": 1,
-          "version": "6.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Directory Utility",
-    "id": "655781cfdfab8c44df923416519b816e39246e4861cca2a72951fad85e1734a0",
     "name": "directory utility",
   },
   Object {
@@ -4078,22 +1954,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:archive utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Archive Utility",
-          "id": "2b6d0e21899448b9860a1a972f1bf2830c10a0137a9ef103a2a55562517488c4",
-          "sizeInByte": 1,
-          "version": "10.15",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Archive Utility",
-    "id": "2b6d0e21899448b9860a1a972f1bf2830c10a0137a9ef103a2a55562517488c4",
     "name": "archive utility",
   },
   Object {
@@ -4101,22 +1965,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:voice memos",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Voice Memos",
-          "id": "d624e8bfe2e697bac6f5ffd804f22392ed6e538ad2019224940e7e1cc3d3e30d",
-          "sizeInByte": 1,
-          "version": "2.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Voice Memos",
-    "id": "d624e8bfe2e697bac6f5ffd804f22392ed6e538ad2019224940e7e1cc3d3e30d",
     "name": "voice memos",
   },
   Object {
@@ -4124,22 +1976,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:voiceover utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VoiceOver Utility",
-          "id": "bb5fc79336832571016cd14deeeef480291ad47db60b0f5a1b414a08e61fa2bf",
-          "sizeInByte": 1,
-          "version": "10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VoiceOver Utility",
-    "id": "bb5fc79336832571016cd14deeeef480291ad47db60b0f5a1b414a08e61fa2bf",
     "name": "voiceover utility",
   },
   Object {
@@ -4147,22 +1987,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:terminal",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Terminal",
-          "id": "1c09e47b02845b76a89fd016ea33f3f2ad46a4a796815b6d9f34ce6a8381b409",
-          "sizeInByte": 1,
-          "version": "2.11",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Terminal",
-    "id": "1c09e47b02845b76a89fd016ea33f3f2ad46a4a796815b6d9f34ce6a8381b409",
     "name": "terminal",
   },
   Object {
@@ -4170,22 +1998,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:system information",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "System Information",
-          "id": "c1c8dfbce917e376e1a4b6e13c1e4a7f35dacd0231f63463aa2dae75d72e68fc",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "System Information",
-    "id": "c1c8dfbce917e376e1a4b6e13c1e4a7f35dacd0231f63463aa2dae75d72e68fc",
     "name": "system information",
   },
   Object {
@@ -4193,22 +2009,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:script editor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Script Editor",
-          "id": "9ab05d4d5c3d8cc7560ae5a10d79a368807affb08574fc3ab1d09e6279af1219",
-          "sizeInByte": 1,
-          "version": "2.11",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Script Editor",
-    "id": "9ab05d4d5c3d8cc7560ae5a10d79a368807affb08574fc3ab1d09e6279af1219",
     "name": "script editor",
   },
   Object {
@@ -4216,22 +2020,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:keychain access",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Keychain Access",
-          "id": "390645d6fe76f8be5608b1f267c1405b66e53922444775753e01a3041c7a1157",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Keychain Access",
-    "id": "390645d6fe76f8be5608b1f267c1405b66e53922444775753e01a3041c7a1157",
     "name": "keychain access",
   },
   Object {
@@ -4239,22 +2031,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:grapher",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Grapher",
-          "id": "5bfc656a3602b4bac354b489841d41772b28d0fb9dea6e315388f30923aac56e",
-          "sizeInByte": 1,
-          "version": "2.7",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Grapher",
-    "id": "5bfc656a3602b4bac354b489841d41772b28d0fb9dea6e315388f30923aac56e",
     "name": "grapher",
   },
   Object {
@@ -4262,22 +2042,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:disk utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Disk Utility",
-          "id": "8f8acd370eea2d3f02ef2021a65af4ab709580fb409277920c16027c4f01be91",
-          "sizeInByte": 1,
-          "version": "20.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Disk Utility",
-    "id": "8f8acd370eea2d3f02ef2021a65af4ab709580fb409277920c16027c4f01be91",
     "name": "disk utility",
   },
   Object {
@@ -4285,22 +2053,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:console",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Console",
-          "id": "130aa0c13ba3059a6721bfb1e508535a8dc17a2764115a46d9e6687c908b3d66",
-          "sizeInByte": 1,
-          "version": "1.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Console",
-    "id": "130aa0c13ba3059a6721bfb1e508535a8dc17a2764115a46d9e6687c908b3d66",
     "name": "console",
   },
   Object {
@@ -4308,22 +2064,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:colorsync utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ColorSync Utility",
-          "id": "5f87aeb80d984399b408018254acb5db658219dcde0028552a1665829dda4dfc",
-          "sizeInByte": 1,
-          "version": "4.14.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ColorSync Utility",
-    "id": "5f87aeb80d984399b408018254acb5db658219dcde0028552a1665829dda4dfc",
     "name": "colorsync utility",
   },
   Object {
@@ -4331,22 +2075,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:boot camp assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Boot Camp Assistant",
-          "id": "c3c51572c4cd46ea036a15b392f817026b7a642dd467c3f651d22e73721f9777",
-          "sizeInByte": 1,
-          "version": "6.1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Boot Camp Assistant",
-    "id": "c3c51572c4cd46ea036a15b392f817026b7a642dd467c3f651d22e73721f9777",
     "name": "boot camp assistant",
   },
   Object {
@@ -4354,22 +2086,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:bluetooth file exchange",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Bluetooth File Exchange",
-          "id": "9809538ba987d660473683f2f9b2871f37ff2010e8d95697c08ef1e05af58b10",
-          "sizeInByte": 1,
-          "version": "8.0.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Bluetooth File Exchange",
-    "id": "9809538ba987d660473683f2f9b2871f37ff2010e8d95697c08ef1e05af58b10",
     "name": "bluetooth file exchange",
   },
   Object {
@@ -4377,22 +2097,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:audio midi setup",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Audio MIDI Setup",
-          "id": "aca6d0c9da4bc27aa2a495906f4dd4a8125a487a266c2ec63253a0c31f416a1d",
-          "sizeInByte": 1,
-          "version": "3.5",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Audio MIDI Setup",
-    "id": "aca6d0c9da4bc27aa2a495906f4dd4a8125a487a266c2ec63253a0c31f416a1d",
     "name": "audio midi setup",
   },
   Object {
@@ -4400,22 +2108,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:airport utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AirPort Utility",
-          "id": "e7131958159d4aa849ddf88b13fa961dbbfb816188a60130844de9cc7a49bdaf",
-          "sizeInByte": 1,
-          "version": "6.3.9",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AirPort Utility",
-    "id": "e7131958159d4aa849ddf88b13fa961dbbfb816188a60130844de9cc7a49bdaf",
     "name": "airport utility",
   },
   Object {
@@ -4423,22 +2119,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:activity monitor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Activity Monitor",
-          "id": "50c78ed5fcfa14b533cc1307182c43651425cede6815cc7535d7abf24b7453d1",
-          "sizeInByte": 1,
-          "version": "10.14",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Activity Monitor",
-    "id": "50c78ed5fcfa14b533cc1307182c43651425cede6815cc7535d7abf24b7453d1",
     "name": "activity monitor",
   },
   Object {
@@ -4446,22 +2130,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:textedit",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TextEdit",
-          "id": "e9c568bd3deb14ec3c03dc526509f00fbf7195d0bdc0b3e0dcb0ebcaf6917ff2",
-          "sizeInByte": 1,
-          "version": "1.16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TextEdit",
-    "id": "e9c568bd3deb14ec3c03dc526509f00fbf7195d0bdc0b3e0dcb0ebcaf6917ff2",
     "name": "textedit",
   },
   Object {
@@ -4469,22 +2141,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:tv",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TV",
-          "id": "b325b63f3d22c6c07679d74351de122ae19fb74f34c4a7994a3d682c15e26ad9",
-          "sizeInByte": 1,
-          "version": "1.1.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TV",
-    "id": "b325b63f3d22c6c07679d74351de122ae19fb74f34c4a7994a3d682c15e26ad9",
     "name": "tv",
   },
   Object {
@@ -4492,22 +2152,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:stocks",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Stocks",
-          "id": "d319bd764515490ac0cbdb93777ba500ca55195251fca7f1313090e6fbc8ba31",
-          "sizeInByte": 1,
-          "version": "3.2.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Stocks",
-    "id": "d319bd764515490ac0cbdb93777ba500ca55195251fca7f1313090e6fbc8ba31",
     "name": "stocks",
   },
   Object {
@@ -4515,22 +2163,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:stickies",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Stickies",
-          "id": "0dd168f92737f787a08aeaa6d80c98c8ebf3906249f3fc1ebed360de195d4d27",
-          "sizeInByte": 1,
-          "version": "10.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Stickies",
-    "id": "0dd168f92737f787a08aeaa6d80c98c8ebf3906249f3fc1ebed360de195d4d27",
     "name": "stickies",
   },
   Object {
@@ -4538,22 +2174,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:reminders",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Reminders",
-          "id": "1494718fa0ad38272c834f517e4965b7dbe410bb6f8f15c64ddb30b2e9d01dbe",
-          "sizeInByte": 1,
-          "version": "7.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Reminders",
-    "id": "1494718fa0ad38272c834f517e4965b7dbe410bb6f8f15c64ddb30b2e9d01dbe",
     "name": "reminders",
   },
   Object {
@@ -4561,22 +2185,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:quicktime player",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "QuickTime Player",
-          "id": "795370b40c360f8bc5859620ec4c44febe3b5fd809a3aa518ff161f16dac4647",
-          "sizeInByte": 1,
-          "version": "10.5",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "QuickTime Player",
-    "id": "795370b40c360f8bc5859620ec4c44febe3b5fd809a3aa518ff161f16dac4647",
     "name": "quicktime player",
   },
   Object {
@@ -4584,22 +2196,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:preview",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Preview",
-          "id": "4d08dc4c05cca05128b385e1d95ffbf7c55a46d0ff0256e65407e59fcbd3d858",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Preview",
-    "id": "4d08dc4c05cca05128b385e1d95ffbf7c55a46d0ff0256e65407e59fcbd3d858",
     "name": "preview",
   },
   Object {
@@ -4607,22 +2207,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:podcasts",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Podcasts",
-          "id": "8d6a8ff1a814cb884811c2d4b2f0f20a5affd5ffa20eafb33d221de1aa7206b1",
-          "sizeInByte": 1,
-          "version": "1.1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Podcasts",
-    "id": "8d6a8ff1a814cb884811c2d4b2f0f20a5affd5ffa20eafb33d221de1aa7206b1",
     "name": "podcasts",
   },
   Object {
@@ -4630,22 +2218,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:photos",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Photos",
-          "id": "1ffea32cc98d71813a95721d1041ec0c78da364595165534f2fbfe3890c188fc",
-          "sizeInByte": 1,
-          "version": "6.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Photos",
-    "id": "1ffea32cc98d71813a95721d1041ec0c78da364595165534f2fbfe3890c188fc",
     "name": "photos",
   },
   Object {
@@ -4653,22 +2229,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:photo booth",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Photo Booth",
-          "id": "e144a242f92dca61ec0ab0d47e02b36cdb78d98d8380e138008fd0769dfb1909",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Photo Booth",
-    "id": "e144a242f92dca61ec0ab0d47e02b36cdb78d98d8380e138008fd0769dfb1909",
     "name": "photo booth",
   },
   Object {
@@ -4676,22 +2240,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:music",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Music",
-          "id": "309a8b6eabe5f7ade3072b95eea8b8848a7268a099ea9dff2ba11ca87e5aaf99",
-          "sizeInByte": 1,
-          "version": "1.1.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Music",
-    "id": "309a8b6eabe5f7ade3072b95eea8b8848a7268a099ea9dff2ba11ca87e5aaf99",
     "name": "music",
   },
   Object {
@@ -4699,22 +2251,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:maps",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Maps",
-          "id": "a8d93981cc00c79563aee5b0da8572041549d602eca05aeec2ac1682bf9e8217",
-          "sizeInByte": 1,
-          "version": "3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Maps",
-    "id": "a8d93981cc00c79563aee5b0da8572041549d602eca05aeec2ac1682bf9e8217",
     "name": "maps",
   },
   Object {
@@ -4722,22 +2262,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:home",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Home",
-          "id": "e3bd10b10f4d13f7a25d4bc762ca976ec9aee6f32b60423faa679bd7c6e006e4",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Home",
-    "id": "e3bd10b10f4d13f7a25d4bc762ca976ec9aee6f32b60423faa679bd7c6e006e4",
     "name": "home",
   },
   Object {
@@ -4745,22 +2273,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:font book",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Font Book",
-          "id": "d3fc437a15c0e8ed388315ca318e0e268827013ebd59fd69e7ddc41e7de7f0fa",
-          "sizeInByte": 1,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Font Book",
-    "id": "d3fc437a15c0e8ed388315ca318e0e268827013ebd59fd69e7ddc41e7de7f0fa",
     "name": "font book",
   },
   Object {
@@ -4768,22 +2284,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:find my",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Find My",
-          "id": "83e28e3ca0f304d200d6b9b79f6ff2ac1ae94c4eb43771ccca42efcd90058025",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Find My",
-    "id": "83e28e3ca0f304d200d6b9b79f6ff2ac1ae94c4eb43771ccca42efcd90058025",
     "name": "find my",
   },
   Object {
@@ -4791,22 +2295,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:facetime",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FaceTime",
-          "id": "02dc5bad29d64a6b0dedcd4d75dcd1d78b3f38a051edd9d86cc21f5a1fd11bcf",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FaceTime",
-    "id": "02dc5bad29d64a6b0dedcd4d75dcd1d78b3f38a051edd9d86cc21f5a1fd11bcf",
     "name": "facetime",
   },
   Object {
@@ -4814,22 +2306,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dictionary",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Dictionary",
-          "id": "cc057d6ab08ea1fcae9465b256505373c207c825fc2c999c9b397dfa8825f904",
-          "sizeInByte": 1,
-          "version": "2.3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Dictionary",
-    "id": "cc057d6ab08ea1fcae9465b256505373c207c825fc2c999c9b397dfa8825f904",
     "name": "dictionary",
   },
   Object {
@@ -4837,22 +2317,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:contacts",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Contacts",
-          "id": "81796c845527eea9ebd8226529c616ced4e8e3fcce19e03699e896933dcf95a6",
-          "sizeInByte": 1,
-          "version": "13.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Contacts",
-    "id": "81796c845527eea9ebd8226529c616ced4e8e3fcce19e03699e896933dcf95a6",
     "name": "contacts",
   },
   Object {
@@ -4860,22 +2328,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:chess",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Chess",
-          "id": "8e3cf493d179d756d73a6911e181c280ca3fbcf745726d553f644355fbcc767e",
-          "sizeInByte": 1,
-          "version": "3.18",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Chess",
-    "id": "8e3cf493d179d756d73a6911e181c280ca3fbcf745726d553f644355fbcc767e",
     "name": "chess",
   },
   Object {
@@ -4883,22 +2339,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:calendar",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Calendar",
-          "id": "583a72c989f05c5b045a028477a347d29df1161faaca1609fac656bddaf488fa",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Calendar",
-    "id": "583a72c989f05c5b045a028477a347d29df1161faaca1609fac656bddaf488fa",
     "name": "calendar",
   },
   Object {
@@ -4906,22 +2350,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:calculator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Calculator",
-          "id": "c3b2b3cbd94b57b7003dd12f4ba01a683e61eb4181a238896f792b00a0da563a",
-          "sizeInByte": 1,
-          "version": "10.16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Calculator",
-    "id": "c3b2b3cbd94b57b7003dd12f4ba01a683e61eb4181a238896f792b00a0da563a",
     "name": "calculator",
   },
   Object {
@@ -4929,22 +2361,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:books",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Books",
-          "id": "1eaad75a95828078b68fa29feeb99908bbe6513f9edd66614abae1cc3a120917",
-          "sizeInByte": 1,
-          "version": "3.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Books",
-    "id": "1eaad75a95828078b68fa29feeb99908bbe6513f9edd66614abae1cc3a120917",
     "name": "books",
   },
   Object {
@@ -4952,22 +2372,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:automator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Automator",
-          "id": "252987e066934e01967e3be4c39f87f725129f32ec3d160c3ef1597f1b350022",
-          "sizeInByte": 1,
-          "version": "2.10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Automator",
-    "id": "252987e066934e01967e3be4c39f87f725129f32ec3d160c3ef1597f1b350022",
     "name": "automator",
   },
   Object {
@@ -4975,22 +2383,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:app store",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "App Store",
-          "id": "656a2608e3ef8a459830c978cb1ba50f8cda481e6f7f9b51eb6522071b84f72b",
-          "sizeInByte": 1,
-          "version": "3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "App Store",
-    "id": "656a2608e3ef8a459830c978cb1ba50f8cda481e6f7f9b51eb6522071b84f72b",
     "name": "app store",
   },
   Object {
@@ -4998,22 +2394,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:recents",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Recents",
-          "id": "86e35c8bf0fb179a71016f5123caf53b50122c5560dcb58fda6997fe03b8e7e2",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Recents",
-    "id": "86e35c8bf0fb179a71016f5123caf53b50122c5560dcb58fda6997fe03b8e7e2",
     "name": "recents",
   },
   Object {
@@ -5021,22 +2405,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:computer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Computer",
-          "id": "1b97b00152c0485cd33be155e87d8112a2d5154e4ce32041b1b2bf04242db6e4",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Computer",
-    "id": "1b97b00152c0485cd33be155e87d8112a2d5154e4ce32041b1b2bf04242db6e4",
     "name": "computer",
   },
   Object {
@@ -5044,22 +2416,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:icloud drive",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "iCloud Drive",
-          "id": "c8112fd4915ed2b5227f1725da14d44fbaa5d336476c584fa075201473756fc3",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "iCloud Drive",
-    "id": "c8112fd4915ed2b5227f1725da14d44fbaa5d336476c584fa075201473756fc3",
     "name": "icloud drive",
   },
   Object {
@@ -5067,22 +2427,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:network",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Network",
-          "id": "c281342237f1748505b4cb7fc6826ed5fdb8babcd0a674d71b049504870d08e6",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Network",
-    "id": "c281342237f1748505b4cb7fc6826ed5fdb8babcd0a674d71b049504870d08e6",
     "name": "network",
   },
   Object {
@@ -5090,22 +2438,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:airdrop",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AirDrop",
-          "id": "2cf56672dcc530e98ce86f8e8a0c7e02432cece18fd6c73e161ad586cd44979f",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AirDrop",
-    "id": "2cf56672dcc530e98ce86f8e8a0c7e02432cece18fd6c73e161ad586cd44979f",
     "name": "airdrop",
   },
   Object {
@@ -5113,22 +2449,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ios app installer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "iOS App Installer",
-          "id": "4fa9cd60458d93df7e3adbdd3ac69555576d1e71748002e7b2de91825aacc5b5",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "iOS App Installer",
-    "id": "4fa9cd60458d93df7e3adbdd3ac69555576d1e71748002e7b2de91825aacc5b5",
     "name": "ios app installer",
   },
   Object {
@@ -5136,22 +2460,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:storage management",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Storage Management",
-          "id": "d99424cb97e1e75e41570d28b176131736a357ff72eb00fda9afde2396708db8",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Storage Management",
-    "id": "d99424cb97e1e75e41570d28b176131736a357ff72eb00fda9afde2396708db8",
     "name": "storage management",
   },
   Object {
@@ -5159,22 +2471,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ticket viewer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Ticket Viewer",
-          "id": "1392d646f37f9f7aa8fd4e9e679661e473f26282ebcb9811af2e59d75eedf069",
-          "sizeInByte": 1,
-          "version": "4.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Ticket Viewer",
-    "id": "1392d646f37f9f7aa8fd4e9e679661e473f26282ebcb9811af2e59d75eedf069",
     "name": "ticket viewer",
   },
   Object {
@@ -5182,22 +2482,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:about this mac",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "About This Mac",
-          "id": "9393495ba2748de77c7bd8cdb03a51874caafb0ce0d8e4e8e20cead5b5f1634e",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "About This Mac",
-    "id": "9393495ba2748de77c7bd8cdb03a51874caafb0ce0d8e4e8e20cead5b5f1634e",
     "name": "about this mac",
   },
   Object {
@@ -5205,22 +2493,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:network utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Network Utility",
-          "id": "e8b7cc7c64263987d4af508462a4de3932a07545f2dd3485ef78e71a43abcd62",
-          "sizeInByte": 1,
-          "version": "1.9.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Network Utility",
-    "id": "e8b7cc7c64263987d4af508462a4de3932a07545f2dd3485ef78e71a43abcd62",
     "name": "network utility",
   },
   Object {
@@ -5228,22 +2504,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dvd player",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "DVD Player",
-          "id": "c032bbf88eaa03b092aef73508eb68a7eafa01d4af292654c339f44e71f3154c",
-          "sizeInByte": 1,
-          "version": "6.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "DVD Player",
-    "id": "c032bbf88eaa03b092aef73508eb68a7eafa01d4af292654c339f44e71f3154c",
     "name": "dvd player",
   },
   Object {
@@ -5251,22 +2515,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:expansion slot utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Expansion Slot Utility",
-          "id": "c7f6214a7755f361748e5b18113bfd137f5bf411ec3381d59436f5eb8a40f0ea",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Expansion Slot Utility",
-    "id": "c7f6214a7755f361748e5b18113bfd137f5bf411ec3381d59436f5eb8a40f0ea",
     "name": "expansion slot utility",
   },
   Object {
@@ -5274,22 +2526,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:folder actions setup",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Folder Actions Setup",
-          "id": "31ef534e792c9b3f30d17dca6b8328eea744f8abf2bd34e080f3de61c5972fae",
-          "sizeInByte": 1,
-          "version": "1.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Folder Actions Setup",
-    "id": "31ef534e792c9b3f30d17dca6b8328eea744f8abf2bd34e080f3de61c5972fae",
     "name": "folder actions setup",
   },
   Object {
@@ -5297,22 +2537,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:feedback assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Feedback Assistant",
-          "id": "16dc2b4d975087327c0ed06f3cf984bbcdfc1f7fcf02348cad343e7c15d746b2",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Feedback Assistant",
-    "id": "16dc2b4d975087327c0ed06f3cf984bbcdfc1f7fcf02348cad343e7c15d746b2",
     "name": "feedback assistant",
   },
   Object {
@@ -5320,22 +2548,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:migration assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Migration Assistant",
-          "id": "b79081c7549f5e5fc4c03502585ee6135d6a5500661da9b6bb88f17627e09c2e",
-          "sizeInByte": 1,
-          "version": "11.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Migration Assistant",
-    "id": "b79081c7549f5e5fc4c03502585ee6135d6a5500661da9b6bb88f17627e09c2e",
     "name": "migration assistant",
   },
   Object {
@@ -5343,22 +2559,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:screenshot",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Screenshot",
-          "id": "1c3fead68e44ad36765dd03b4a68175aafad7b945c6a5eaad6a016217c5b6115",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Screenshot",
-    "id": "1c3fead68e44ad36765dd03b4a68175aafad7b945c6a5eaad6a016217c5b6115",
     "name": "screenshot",
   },
   Object {
@@ -5366,22 +2570,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:digital color meter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Digital Color Meter",
-          "id": "d3d32da1b975a175e98bdbfdd39ebe51a5f6af898412f54fd5ccf284d4ca0510",
-          "sizeInByte": 1,
-          "version": "5.22",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Digital Color Meter",
-    "id": "d3d32da1b975a175e98bdbfdd39ebe51a5f6af898412f54fd5ccf284d4ca0510",
     "name": "digital color meter",
   },
   Object {
@@ -5389,22 +2581,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:time machine",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Time Machine",
-          "id": "cfbef6f5306f50d1ecf9f28d89dd31c27021f6ba755f28156bf18f914dd83fdd",
-          "sizeInByte": 1,
-          "version": "1.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Time Machine",
-    "id": "cfbef6f5306f50d1ecf9f28d89dd31c27021f6ba755f28156bf18f914dd83fdd",
     "name": "time machine",
   },
   Object {
@@ -5412,22 +2592,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:image capture",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Image Capture",
-          "id": "5d0c997e05dba9c20f2542033ef66be9e89ca7ab903bed581c5e71986a3cbf84",
-          "sizeInByte": 1,
-          "version": "8.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Image Capture",
-    "id": "5d0c997e05dba9c20f2542033ef66be9e89ca7ab903bed581c5e71986a3cbf84",
     "name": "image capture",
   },
   Object {
@@ -5435,22 +2603,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mission control",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Mission Control",
-          "id": "238eda6ebc5498e6d33726147a795e77524a2a434c05720f773e798defac01d7",
-          "sizeInByte": 1,
-          "version": "1.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Mission Control",
-    "id": "238eda6ebc5498e6d33726147a795e77524a2a434c05720f773e798defac01d7",
     "name": "mission control",
   },
   Object {
@@ -5458,22 +2614,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:launchpad",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Launchpad",
-          "id": "4da46059166c035fc46eff406a3e7d9a88ced3cd35030f260ac512f451f59254",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Launchpad",
-    "id": "4da46059166c035fc46eff406a3e7d9a88ced3cd35030f260ac512f451f59254",
     "name": "launchpad",
   },
   Object {
@@ -5481,22 +2625,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:news",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "News",
-          "id": "d44f21f5c22ec2b9c7ff8a3809ba92aca2f5a915287992442f30ddb768ddabbf",
-          "sizeInByte": 1,
-          "version": "6.2.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "News",
-    "id": "d44f21f5c22ec2b9c7ff8a3809ba92aca2f5a915287992442f30ddb768ddabbf",
     "name": "news",
   },
   Object {
@@ -5504,22 +2636,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:chinesetextconverterservice",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ChineseTextConverterService",
-          "id": "00f9a92c87133320e9dbdaa7f7f4e1aa74fd6804a0e6e8dd509aca7ef80c8762",
-          "sizeInByte": 1,
-          "version": "2.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ChineseTextConverterService",
-    "id": "00f9a92c87133320e9dbdaa7f7f4e1aa74fd6804a0e6e8dd509aca7ef80c8762",
     "name": "chinesetextconverterservice",
   },
   Object {
@@ -5527,22 +2647,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:uasharedpasteboardprogressui",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "UASharedPasteboardProgressUI",
-          "id": "e08165f93e11d71e179aeceecb6658e1724f2e029591e62858e023a980a395c5",
-          "sizeInByte": 1,
-          "version": "54.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "UASharedPasteboardProgressUI",
-    "id": "e08165f93e11d71e179aeceecb6658e1724f2e029591e62858e023a980a395c5",
     "name": "uasharedpasteboardprogressui",
   },
   Object {
@@ -5550,22 +2658,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dfrhud",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "DFRHUD",
-          "id": "ba42db4fcc646203a8a6b238ce53ff2a021f7a2e4822e4fc846f99d6dd4b9b95",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "DFRHUD",
-    "id": "ba42db4fcc646203a8a6b238ce53ff2a021f7a2e4822e4fc846f99d6dd4b9b95",
     "name": "dfrhud",
   },
   Object {
@@ -5573,22 +2669,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:speechrecognitionserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SpeechRecognitionServer",
-          "id": "887589a4f520d376ef7aa154c2006e455c0ef7d5846b7ae8ed259b549021d1e3",
-          "sizeInByte": 1,
-          "version": "9.0.30",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SpeechRecognitionServer",
-    "id": "887589a4f520d376ef7aa154c2006e455c0ef7d5846b7ae8ed259b549021d1e3",
     "name": "speechrecognitionserver",
   },
   Object {
@@ -5596,22 +2680,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:aquaappearancehelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AquaAppearanceHelper",
-          "id": "26b811ccd4e5f3474cbfefdb09e1a8f6115dbf7188136e556557fdd0084257ca",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AquaAppearanceHelper",
-    "id": "26b811ccd4e5f3474cbfefdb09e1a8f6115dbf7188136e556557fdd0084257ca",
     "name": "aquaappearancehelper",
   },
   Object {
@@ -5619,22 +2691,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:idsremoteurlconnectionagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "IDSRemoteURLConnectionAgent",
-          "id": "183441ca2bfc0795f24ce975c94a2867f8ae9b6e277182b9d87acdafb1412a67",
-          "sizeInByte": 1,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "IDSRemoteURLConnectionAgent",
-    "id": "183441ca2bfc0795f24ce975c94a2867f8ae9b6e277182b9d87acdafb1412a67",
     "name": "idsremoteurlconnectionagent",
   },
   Object {
@@ -5642,22 +2702,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:imtransferagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "IMTransferAgent",
-          "id": "e98de9688fa1cecd1c9e2ba1bd945edd3ddc28ee0524c41269bc7dab9775f751",
-          "sizeInByte": 1,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "IMTransferAgent",
-    "id": "e98de9688fa1cecd1c9e2ba1bd945edd3ddc28ee0524c41269bc7dab9775f751",
     "name": "imtransferagent",
   },
   Object {
@@ -5665,22 +2713,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:imautomatichistorydeletionagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "IMAutomaticHistoryDeletionAgent",
-          "id": "bc1652db7ec901cf31bc5ed0b44d6e6d0416362e6773652e469f21e986ba2613",
-          "sizeInByte": 1,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "IMAutomaticHistoryDeletionAgent",
-    "id": "bc1652db7ec901cf31bc5ed0b44d6e6d0416362e6773652e469f21e986ba2613",
     "name": "imautomatichistorydeletionagent",
   },
   Object {
@@ -5688,22 +2724,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:imagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "imagent",
-          "id": "f1df8ce945eb1b31fd0055a3a340fee9880c6ad0fe4d94e16289862bdc546409",
-          "sizeInByte": 1,
-          "version": "10.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "imagent",
-    "id": "f1df8ce945eb1b31fd0055a3a340fee9880c6ad0fe4d94e16289862bdc546409",
     "name": "imagent",
   },
   Object {
@@ -5711,22 +2735,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:accessibilityvisualsagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AccessibilityVisualsAgent",
-          "id": "a172ed8ab0f2367f2f9de82aa1d37fd58496ead0e0d9a915db2c9ba626b7522c",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AccessibilityVisualsAgent",
-    "id": "a172ed8ab0f2367f2f9de82aa1d37fd58496ead0e0d9a915db2c9ba626b7522c",
     "name": "accessibilityvisualsagent",
   },
   Object {
@@ -5734,22 +2746,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:aosalertmanager",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AOSAlertManager",
-          "id": "0c617bcd1bfc476e38c6f0692383c891ec0990cfb30cfac4a342b1c4af9ce45a",
-          "sizeInByte": 1,
-          "version": "1.07",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AOSAlertManager",
-    "id": "0c617bcd1bfc476e38c6f0692383c891ec0990cfb30cfac4a342b1c4af9ce45a",
     "name": "aosalertmanager",
   },
   Object {
@@ -5757,22 +2757,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:tamilim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TamilIM",
-          "id": "69d5d59c7d722a2245fc94bda4295f8e4e1219e106aafc09954b0bb4e5e96932",
-          "sizeInByte": 1,
-          "version": "1.6",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TamilIM",
-    "id": "69d5d59c7d722a2245fc94bda4295f8e4e1219e106aafc09954b0bb4e5e96932",
     "name": "tamilim",
   },
   Object {
@@ -5780,22 +2768,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ainuim",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AinuIM",
-          "id": "17bec73fca90f4f774f5af969dd7dfa395c314bcfe1bad68f1de3de62cd852ba",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AinuIM",
-    "id": "17bec73fca90f4f774f5af969dd7dfa395c314bcfe1bad68f1de3de62cd852ba",
     "name": "ainuim",
   },
   Object {
@@ -5803,22 +2779,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:50onpaletteserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "50onPaletteServer",
-          "id": "affb4367e9117ec8a35facdf11153a165fb9f51fe8e6b265439015413f8d001a",
-          "sizeInByte": 1,
-          "version": "1.1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "50onPaletteServer",
-    "id": "affb4367e9117ec8a35facdf11153a165fb9f51fe8e6b265439015413f8d001a",
     "name": "50onpaletteserver",
   },
   Object {
@@ -5826,22 +2790,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:virtualscanner",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VirtualScanner",
-          "id": "22db0f79ee5d44c818e12ca15be350e5ef9222311c9be417cea8af9062c4ddf1",
-          "sizeInByte": 1,
-          "version": "1708.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VirtualScanner",
-    "id": "22db0f79ee5d44c818e12ca15be350e5ef9222311c9be417cea8af9062c4ddf1",
     "name": "virtualscanner",
   },
   Object {
@@ -5849,22 +2801,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:massstoragecamera",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MassStorageCamera",
-          "id": "9253a76bd41609f43ac2f3ccb2df13f4d86adb8f6b317d4e7e93485cafdca472",
-          "sizeInByte": 1,
-          "version": "1708.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MassStorageCamera",
-    "id": "9253a76bd41609f43ac2f3ccb2df13f4d86adb8f6b317d4e7e93485cafdca472",
     "name": "massstoragecamera",
   },
   Object {
@@ -5872,22 +2812,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:syncserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SyncServer",
-          "id": "58ab9102d66ec6f75eacb2c3394823171eb2578614b168dabebadf529b35c317",
-          "sizeInByte": 1,
-          "version": "8.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SyncServer",
-    "id": "58ab9102d66ec6f75eacb2c3394823171eb2578614b168dabebadf529b35c317",
     "name": "syncserver",
   },
   Object {
@@ -5895,22 +2823,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:webkitpluginhost",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "WebKitPluginHost",
-          "id": "09749965280a1d7c521bdcd3e3be5276b1f0041e204c7dc39bcc6a86e507f1c2",
-          "sizeInByte": 1,
-          "version": "610",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "WebKitPluginHost",
-    "id": "09749965280a1d7c521bdcd3e3be5276b1f0041e204c7dc39bcc6a86e507f1c2",
     "name": "webkitpluginhost",
   },
   Object {
@@ -5918,22 +2834,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:wish",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Wish",
-          "id": "0a9648ede10187f5db527618db2b586378cd36a7b28bb04542ffb2492cb2d2e7",
-          "sizeInByte": 1,
-          "version": "8.5.9",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Wish",
-    "id": "0a9648ede10187f5db527618db2b586378cd36a7b28bb04542ffb2492cb2d2e7",
     "name": "wish",
   },
   Object {
@@ -5941,22 +2845,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:quicklookd",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "quicklookd",
-          "id": "b3a6c312dec0c65ca1c5a94836dafe999efb7b2ea819295d06be7232fdaf3c7f",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "quicklookd",
-    "id": "b3a6c312dec0c65ca1c5a94836dafe999efb7b2ea819295d06be7232fdaf3c7f",
     "name": "quicklookd",
   },
   Object {
@@ -5964,22 +2856,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:qlmanage",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "qlmanage",
-          "id": "6b0754ea6f5deef13ed13da30212fd72163d4f5137fc85b956c5c728ff840f78",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "qlmanage",
-    "id": "6b0754ea6f5deef13ed13da30212fd72163d4f5137fc85b956c5c728ff840f78",
     "name": "qlmanage",
   },
   Object {
@@ -5987,22 +2867,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:quicklookuihelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "QuickLookUIHelper",
-          "id": "257ce9f6136fdbd63847a681dfdc513a8b5eb075d347747ce5e96f3a7e2e2dfc",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "QuickLookUIHelper",
-    "id": "257ce9f6136fdbd63847a681dfdc513a8b5eb075d347747ce5e96f3a7e2e2dfc",
     "name": "quicklookuihelper",
   },
   Object {
@@ -6010,22 +2878,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:speechsynthesisserver",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SpeechSynthesisServer",
-          "id": "a9411b902fbbdbb9eed19fa76893a9fa93c28b0b83ecfed98ceb2b6806dbdd02",
-          "sizeInByte": 1,
-          "version": "9.0.51.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SpeechSynthesisServer",
-    "id": "a9411b902fbbdbb9eed19fa76893a9fa93c28b0b83ecfed98ceb2b6806dbdd02",
     "name": "speechsynthesisserver",
   },
   Object {
@@ -6033,22 +2889,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:voiceover",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VoiceOver",
-          "id": "562c319b6193cd91868e25c8e021a1a0e06c6b15b64789548a98161e5cdb0b19",
-          "sizeInByte": 1,
-          "version": "10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VoiceOver",
-    "id": "562c319b6193cd91868e25c8e021a1a0e06c6b15b64789548a98161e5cdb0b19",
     "name": "voiceover",
   },
   Object {
@@ -6056,22 +2900,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:spacestouchbaragent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SpacesTouchBarAgent",
-          "id": "9e0b727b21eaf81619ce58d85e7b7f0aa12dabd2402a0c92b2da0b864b0c2714",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SpacesTouchBarAgent",
-    "id": "9e0b727b21eaf81619ce58d85e7b7f0aa12dabd2402a0c92b2da0b864b0c2714",
     "name": "spacestouchbaragent",
   },
   Object {
@@ -6079,22 +2911,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:addressbooksourcesync",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AddressBookSourceSync",
-          "id": "9eab4a7491c6985a83ca610699cd0a30390fb3f21341926c99bca96476dbfa1b",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AddressBookSourceSync",
-    "id": "9eab4a7491c6985a83ca610699cd0a30390fb3f21341926c99bca96476dbfa1b",
     "name": "addressbooksourcesync",
   },
   Object {
@@ -6102,22 +2922,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:addressbookmanager",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AddressBookManager",
-          "id": "ef068205a311a0b396a8987ce53f1a6e93a3aa2fb7fef36311f27d7d7f26225e",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AddressBookManager",
-    "id": "ef068205a311a0b396a8987ce53f1a6e93a3aa2fb7fef36311f27d7d7f26225e",
     "name": "addressbookmanager",
   },
   Object {
@@ -6125,22 +2933,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:rcd",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "rcd",
-          "id": "ba39599f3740ebecde905343fa8992002b83e80e447db8c44b9e7eef4a9598fa",
-          "sizeInByte": 1,
-          "version": "360",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "rcd",
-    "id": "ba39599f3740ebecde905343fa8992002b83e80e447db8c44b9e7eef4a9598fa",
     "name": "rcd",
   },
   Object {
@@ -6148,22 +2944,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:uikitsystem",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "UIKitSystem",
-          "id": "9b350f77d8d26d6f19f652ddc72b7fe27e9664105966546a8eeb0b75d553582f",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "UIKitSystem",
-    "id": "9b350f77d8d26d6f19f652ddc72b7fe27e9664105966546a8eeb0b75d553582f",
     "name": "uikitsystem",
   },
   Object {
@@ -6171,22 +2955,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:tmhelperagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TMHelperAgent",
-          "id": "5a9ab6043740f5f114981e18fe5cd3c4dccd0e6c465e18dcd33b3683816517dd",
-          "sizeInByte": 1,
-          "version": "10.9",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TMHelperAgent",
-    "id": "5a9ab6043740f5f114981e18fe5cd3c4dccd0e6c465e18dcd33b3683816517dd",
     "name": "tmhelperagent",
   },
   Object {
@@ -6194,22 +2966,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:usernotificationcenter",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "UserNotificationCenter",
-          "id": "7e4079c5117ef2a09d22e36a8932f887a531b4858b46de65212704651ba1eb28",
-          "sizeInByte": 1,
-          "version": "64.101",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "UserNotificationCenter",
-    "id": "7e4079c5117ef2a09d22e36a8932f887a531b4858b46de65212704651ba1eb28",
     "name": "usernotificationcenter",
   },
   Object {
@@ -6217,22 +2977,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:textinputswitcher",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TextInputSwitcher",
-          "id": "d2fa4ce4fa398af91938724c5a7ecd9483d8ba8a9502ec50d4896824fe0fec2d",
-          "sizeInByte": 1,
-          "version": "1.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TextInputSwitcher",
-    "id": "d2fa4ce4fa398af91938724c5a7ecd9483d8ba8a9502ec50d4896824fe0fec2d",
     "name": "textinputswitcher",
   },
   Object {
@@ -6240,22 +2988,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:textinputmenuagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "TextInputMenuAgent",
-          "id": "c36e3c357dd2a57e12454096a368b91234132d3afcd580c4f92867c21640ebc2",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "TextInputMenuAgent",
-    "id": "c36e3c357dd2a57e12454096a368b91234132d3afcd580c4f92867c21640ebc2",
     "name": "textinputmenuagent",
   },
   Object {
@@ -6263,22 +2999,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:script menu",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Script Menu",
-          "id": "7495afc6d21eb714ca5436615a3621bfc3ab6873a000570aca2dfe0cbbc6af1e",
-          "sizeInByte": 1,
-          "version": "1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Script Menu",
-    "id": "7495afc6d21eb714ca5436615a3621bfc3ab6873a000570aca2dfe0cbbc6af1e",
     "name": "script menu",
   },
   Object {
@@ -6286,22 +3010,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:scriptmonitor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ScriptMonitor",
-          "id": "35a67b93055d61d1c22c7e546bbd274b8d19f7d3629298a34d157c76befcc2a3",
-          "sizeInByte": 1,
-          "version": "1.0.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ScriptMonitor",
-    "id": "35a67b93055d61d1c22c7e546bbd274b8d19f7d3629298a34d157c76befcc2a3",
     "name": "scriptmonitor",
   },
   Object {
@@ -6309,22 +3021,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:screensaverengine",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ScreenSaverEngine",
-          "id": "9db742e610111d4df289453a5151cdee281c2d68febe02f33c36cf018f8d7905",
-          "sizeInByte": 1,
-          "version": "5.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ScreenSaverEngine",
-    "id": "9db742e610111d4df289453a5151cdee281c2d68febe02f33c36cf018f8d7905",
     "name": "screensaverengine",
   },
   Object {
@@ -6332,22 +3032,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ssinvitationagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SSInvitationAgent",
-          "id": "d262b2973b8c4700456a62a0490928385319197456513e03a26a6809bf72a994",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SSInvitationAgent",
-    "id": "d262b2973b8c4700456a62a0490928385319197456513e03a26a6809bf72a994",
     "name": "ssinvitationagent",
   },
   Object {
@@ -6355,22 +3043,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:rosetta 2 updater",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Rosetta 2 Updater",
-          "id": "3c8935bab70fefec53189bf39b44da4087c3c56f98da62e6556cb8d7d92e3961",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Rosetta 2 Updater",
-    "id": "3c8935bab70fefec53189bf39b44da4087c3c56f98da62e6556cb8d7d92e3961",
     "name": "rosetta 2 updater",
   },
   Object {
@@ -6378,22 +3054,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:reportpanic",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ReportPanic",
-          "id": "d45ca984bd410aec1b8a38be9c84c3a10ce79bf191f130ca91cd6924ba7f5165",
-          "sizeInByte": 1,
-          "version": "10.13",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ReportPanic",
-    "id": "d45ca984bd410aec1b8a38be9c84c3a10ce79bf191f130ca91cd6924ba7f5165",
     "name": "reportpanic",
   },
   Object {
@@ -6401,22 +3065,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ssassistancecursor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SSAssistanceCursor",
-          "id": "8c68da2fd89e4eedf1a3f05bc876305d2b3e5ac38e5eee0fe492359d9ab84417",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SSAssistanceCursor",
-    "id": "8c68da2fd89e4eedf1a3f05bc876305d2b3e5ac38e5eee0fe492359d9ab84417",
     "name": "ssassistancecursor",
   },
   Object {
@@ -6424,22 +3076,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:share screen request",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Share Screen Request",
-          "id": "4fc8a9056f34b8194f1646d891a3dca9d4c21e672e8da7bdcf9fddf74727da41",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Share Screen Request",
-    "id": "4fc8a9056f34b8194f1646d891a3dca9d4c21e672e8da7bdcf9fddf74727da41",
     "name": "share screen request",
   },
   Object {
@@ -6447,22 +3087,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:rapportuiagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "RapportUIAgent",
-          "id": "b312314930c6f18b8e0fec0b8b140b2a7047f8ee811908183eff2fffe0ee208a",
-          "sizeInByte": 1,
-          "version": "2.3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "RapportUIAgent",
-    "id": "b312314930c6f18b8e0fec0b8b140b2a7047f8ee811908183eff2fffe0ee208a",
     "name": "rapportuiagent",
   },
   Object {
@@ -6470,22 +3098,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:lockscreen",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "LockScreen",
-          "id": "46112a5f4d999443b1ae8f4ee84ce5a3b7900a3cd35dcb528c66a082023180b7",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "LockScreen",
-    "id": "46112a5f4d999443b1ae8f4ee84ce5a3b7900a3cd35dcb528c66a082023180b7",
     "name": "lockscreen",
   },
   Object {
@@ -6493,22 +3109,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:ssdraghelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "SSDragHelper",
-          "id": "ecb9001c1c87c245ae83d89496798fc813b3119ca37eeb688d4b75434a98b84b",
-          "sizeInByte": 1,
-          "version": "3.9.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "SSDragHelper",
-    "id": "ecb9001c1c87c245ae83d89496798fc813b3119ca37eeb688d4b75434a98b84b",
     "name": "ssdraghelper",
   },
   Object {
@@ -6516,22 +3120,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:registerpluginimapp",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "RegisterPluginIMApp",
-          "id": "c9f1f948dd19e34ea2eb2cd15916c2d0c546cc075daa91490e4817f45dee004c",
-          "sizeInByte": 1,
-          "version": "24",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "RegisterPluginIMApp",
-    "id": "c9f1f948dd19e34ea2eb2cd15916c2d0c546cc075daa91490e4817f45dee004c",
     "name": "registerpluginimapp",
   },
   Object {
@@ -6539,22 +3131,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:paired devices",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Paired Devices",
-          "id": "890b41fdea99488ac932a5c93e281c832286d66f82a98861fbb84bf706040354",
-          "sizeInByte": 1,
-          "version": "2.3.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Paired Devices",
-    "id": "890b41fdea99488ac932a5c93e281c832286d66f82a98861fbb84bf706040354",
     "name": "paired devices",
   },
   Object {
@@ -6562,22 +3142,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:odsagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "ODSAgent",
-          "id": "1206d65d8c9fddbd532c0b95740fd9d3d71fd6bef0f633b5f61196161cd9bb42",
-          "sizeInByte": 1,
-          "version": "1.8",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "ODSAgent",
-    "id": "1206d65d8c9fddbd532c0b95740fd9d3d71fd6bef0f633b5f61196161cd9bb42",
     "name": "odsagent",
   },
   Object {
@@ -6585,22 +3153,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pipagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PIPAgent",
-          "id": "d10a245dfe4ef0dadbb27d18dfbf0ea78764dc0a5cc548d2baba828883a341d0",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PIPAgent",
-    "id": "d10a245dfe4ef0dadbb27d18dfbf0ea78764dc0a5cc548d2baba828883a341d0",
     "name": "pipagent",
   },
   Object {
@@ -6608,22 +3164,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:nowplayingtouchui",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "NowPlayingTouchUI",
-          "id": "202cc54f5fcfec74f37ae6caec9f8f18d4617e74be65e7888aeca51d2cb9526d",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "NowPlayingTouchUI",
-    "id": "202cc54f5fcfec74f37ae6caec9f8f18d4617e74be65e7888aeca51d2cb9526d",
     "name": "nowplayingtouchui",
   },
   Object {
@@ -6631,22 +3175,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pass viewer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Pass Viewer",
-          "id": "e3918d6a1af0524b60a631e518dc31c2633cbfe3966adf27257276afdd4bde88",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Pass Viewer",
-    "id": "e3918d6a1af0524b60a631e518dc31c2633cbfe3966adf27257276afdd4bde88",
     "name": "pass viewer",
   },
   Object {
@@ -6654,22 +3186,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:osduihelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OSDUIHelper",
-          "id": "601f33253a5448090476820d519cec42c8202f4d16dd8f2ac295ebf7080a03af",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OSDUIHelper",
-    "id": "601f33253a5448090476820d519cec42c8202f4d16dd8f2ac295ebf7080a03af",
     "name": "osduihelper",
   },
   Object {
@@ -6677,22 +3197,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:powerchime",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PowerChime",
-          "id": "1b5e3beba7e56cc51aae941f0dcb8ef2f7620b9cc85adcaa8d66c7879981f063",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PowerChime",
-    "id": "1b5e3beba7e56cc51aae941f0dcb8ef2f7620b9cc85adcaa8d66c7879981f063",
     "name": "powerchime",
   },
   Object {
@@ -6700,22 +3208,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:memory slot utility",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Memory Slot Utility",
-          "id": "ca79bb58df896863d6f516b1ed96af4def133bf9d38435d1dca6d7b425fb9e7b",
-          "sizeInByte": 1,
-          "version": "1.5.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Memory Slot Utility",
-    "id": "ca79bb58df896863d6f516b1ed96af4def133bf9d38435d1dca6d7b425fb9e7b",
     "name": "memory slot utility",
   },
   Object {
@@ -6723,22 +3219,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:javalauncher",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "JavaLauncher",
-          "id": "12cfddb851c7f867952cbfa171def27008c67bc2a76b44a16c03468acc54390b",
-          "sizeInByte": 1,
-          "version": "317",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "JavaLauncher",
-    "id": "12cfddb851c7f867952cbfa171def27008c67bc2a76b44a16c03468acc54390b",
     "name": "javalauncher",
   },
   Object {
@@ -6746,22 +3230,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:filesystemuiagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FileSystemUIAgent",
-          "id": "45363e72b4541f2388596d2de477d9406eb8f2a7398da9652b97c4b3fb59818a",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FileSystemUIAgent",
-    "id": "45363e72b4541f2388596d2de477d9406eb8f2a7398da9652b97c4b3fb59818a",
     "name": "filesystemuiagent",
   },
   Object {
@@ -6769,22 +3241,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:locationmenu",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "LocationMenu",
-          "id": "d927bd2cd0f73e72c2bf1dc96c26443bd859cfa551ef2bb4f90000126cba6f1c",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "LocationMenu",
-    "id": "d927bd2cd0f73e72c2bf1dc96c26443bd859cfa551ef2bb4f90000126cba6f1c",
     "name": "locationmenu",
   },
   Object {
@@ -6792,22 +3252,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:folderactionsdispatcher",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "FolderActionsDispatcher",
-          "id": "78861b780d332af453ebf9aea9bb183c0d92c60284042bb2bd44cb9665b29f2d",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "FolderActionsDispatcher",
-    "id": "78861b780d332af453ebf9aea9bb183c0d92c60284042bb2bd44cb9665b29f2d",
     "name": "folderactionsdispatcher",
   },
   Object {
@@ -6815,22 +3263,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:escrowsecurityalert",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "EscrowSecurityAlert",
-          "id": "76713d3c4830c803306261f6385fe0890409dcf0e22b2f9e8c38c2cc647b3c01",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "EscrowSecurityAlert",
-    "id": "76713d3c4830c803306261f6385fe0890409dcf0e22b2f9e8c38c2cc647b3c01",
     "name": "escrowsecurityalert",
   },
   Object {
@@ -6838,22 +3274,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dwell control",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Dwell Control",
-          "id": "96ac6281eb8722a3b32dd93b7934349cdae1c83ac6550032b0f62e01ef3f4c8f",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Dwell Control",
-    "id": "96ac6281eb8722a3b32dd93b7934349cdae1c83ac6550032b0f62e01ef3f4c8f",
     "name": "dwell control",
   },
   Object {
@@ -6861,22 +3285,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:dischelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "DiscHelper",
-          "id": "7e2f463874ab7c06b2a6a6f42c6ba830e212a146181bb56882bcaee0d4ddec11",
-          "sizeInByte": 1,
-          "version": "1.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "DiscHelper",
-    "id": "7e2f463874ab7c06b2a6a6f42c6ba830e212a146181bb56882bcaee0d4ddec11",
     "name": "dischelper",
   },
   Object {
@@ -6884,22 +3296,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:database events",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Database Events",
-          "id": "dca905dde2da0a732485ed0fa1424ae9e6d882edc7e458fdc4234099fad59760",
-          "sizeInByte": 1,
-          "version": "1.0.6",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Database Events",
-    "id": "dca905dde2da0a732485ed0fa1424ae9e6d882edc7e458fdc4234099fad59760",
     "name": "database events",
   },
   Object {
@@ -6907,22 +3307,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:corelocationagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "CoreLocationAgent",
-          "id": "63a9e0af448e947f76120c5c40e4dcb5a33ec9cc59a92b9ac8eb3a4801632efc",
-          "sizeInByte": 1,
-          "version": "2420.12.16",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "CoreLocationAgent",
-    "id": "63a9e0af448e947f76120c5c40e4dcb5a33ec9cc59a92b9ac8eb3a4801632efc",
     "name": "corelocationagent",
   },
   Object {
@@ -6930,22 +3318,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:calendarfilehandler",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "CalendarFileHandler",
-          "id": "fa9dbb63ef98120618d114428c48eb53cf249aac47b4988cca8c77f2b21554fa",
-          "sizeInByte": 1,
-          "version": "8.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "CalendarFileHandler",
-    "id": "fa9dbb63ef98120618d114428c48eb53cf249aac47b4988cca8c77f2b21554fa",
     "name": "calendarfilehandler",
   },
   Object {
@@ -6953,22 +3329,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:automator installer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Automator Installer",
-          "id": "ccc112e8190f270ff7688c2cc50a96134806f280289f49467b9b77edb5c1e6b6",
-          "sizeInByte": 1,
-          "version": "2.10",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Automator Installer",
-    "id": "ccc112e8190f270ff7688c2cc50a96134806f280289f49467b9b77edb5c1e6b6",
     "name": "automator installer",
   },
   Object {
@@ -6976,22 +3340,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:bluetooth setup assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Bluetooth Setup Assistant",
-          "id": "47c2719ce17301d731dd97fe32c638b88c6fc00a1f04e4f9c1944c5b2ae07f15",
-          "sizeInByte": 1,
-          "version": "8.0.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Bluetooth Setup Assistant",
-    "id": "47c2719ce17301d731dd97fe32c638b88c6fc00a1f04e4f9c1944c5b2ae07f15",
     "name": "bluetooth setup assistant",
   },
   Object {
@@ -6999,22 +3351,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:airplayuiagent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AirPlayUIAgent",
-          "id": "57e0e3a565aebb7a759ff2651a0805b014404a3d6e1350b287aa43f1566cd44d",
-          "sizeInByte": 1,
-          "version": "2.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AirPlayUIAgent",
-    "id": "57e0e3a565aebb7a759ff2651a0805b014404a3d6e1350b287aa43f1566cd44d",
     "name": "airplayuiagent",
   },
   Object {
@@ -7022,22 +3362,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:airport base station agent",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AirPort Base Station Agent",
-          "id": "3cbb22daa85014ff8b52427edb23d3301d883844c35c31b040417dc40c7a789f",
-          "sizeInByte": 1,
-          "version": "2.2.1",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AirPort Base Station Agent",
-    "id": "3cbb22daa85014ff8b52427edb23d3301d883844c35c31b040417dc40c7a789f",
     "name": "airport base station agent",
   },
   Object {
@@ -7045,22 +3373,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:addressbookurlforwarder",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "AddressBookUrlForwarder",
-          "id": "a485ddbaaecb9cbb41b43cf2527ebd0da63dab93f2f6f26818858b3dac46067c",
-          "sizeInByte": 1,
-          "version": "11.0",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "AddressBookUrlForwarder",
-    "id": "a485ddbaaecb9cbb41b43cf2527ebd0da63dab93f2f6f26818858b3dac46067c",
     "name": "addressbookurlforwarder",
   },
   Object {
@@ -7068,22 +3384,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:automator application stub",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Automator Application Stub",
-          "id": "3cb77f936f9313648b4f80da8e1f2a527d17868b90f8a755462f2e6583924d53",
-          "sizeInByte": 1,
-          "version": "1.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Automator Application Stub",
-    "id": "3cb77f936f9313648b4f80da8e1f2a527d17868b90f8a755462f2e6583924d53",
     "name": "automator application stub",
   },
   Object {
@@ -7091,22 +3395,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:j1-endpoint-agent-darwin",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "j1-endpoint-agent-darwin",
-          "id": "c6009c02ebf8e5976511d753ac427fae733166850b7dfef69df8d0073428339f",
-          "sizeInByte": 71,
-          "version": null,
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "j1-endpoint-agent-darwin",
-    "id": "c6009c02ebf8e5976511d753ac427fae733166850b7dfef69df8d0073428339f",
     "name": "j1-endpoint-agent-darwin",
   },
   Object {
@@ -7114,22 +3406,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:standaloneupdaterdaemon",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "StandaloneUpdaterDaemon",
-          "id": "200877984fe166584aa9cfc83763bdf3ac232446c0dc05ce4b52ef69d8425558",
-          "sizeInByte": 119040,
-          "version": "20114.0607.0002",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "StandaloneUpdaterDaemon",
-    "id": "200877984fe166584aa9cfc83763bdf3ac232446c0dc05ce4b52ef69d8425558",
     "name": "standaloneupdaterdaemon",
   },
   Object {
@@ -7137,22 +3417,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:com.docker.vmnetd",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "com.docker.vmnetd",
-          "id": "f51ae5279a845c36266c220d4f27e016a06c26c912abf29c518754261866a925",
-          "sizeInByte": 3144224,
-          "version": "0.3",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "com.docker.vmnetd",
-    "id": "f51ae5279a845c36266c220d4f27e016a06c26c912abf29c518754261866a925",
     "name": "com.docker.vmnetd",
   },
   Object {
@@ -7160,22 +3428,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:onedriveupdaterdaemon",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OneDriveUpdaterDaemon",
-          "id": "5f703ee642248bf9b40dd88f9e6d6b188147b2996fb3067506d9076d5facba86",
-          "sizeInByte": 171664,
-          "version": "21002.0104.0005",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OneDriveUpdaterDaemon",
-    "id": "5f703ee642248bf9b40dd88f9e6d6b188147b2996fb3067506d9076d5facba86",
     "name": "onedriveupdaterdaemon",
   },
   Object {
@@ -7183,22 +3439,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:vmware carbonblack cloud sensor",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "VMware CarbonBlack Cloud Sensor",
-          "id": "224f38cefc78ba43a5eb4919f04866d7a9792917c34e6d25f24d75f7ba102764",
-          "sizeInByte": 10078256,
-          "version": "3.5.1fc19",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "VMware CarbonBlack Cloud Sensor",
-    "id": "224f38cefc78ba43a5eb4919f04866d7a9792917c34e6d25f24d75f7ba102764",
     "name": "vmware carbonblack cloud sensor",
   },
   Object {
@@ -7206,22 +3450,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pritunl-service",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "pritunl-service",
-          "id": "6a5fcafbcad4a6cf44211c962fcb8ba988f8b5dfba9dafff8e554df0fda019a0",
-          "sizeInByte": 16815360,
-          "version": null,
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "pritunl-service",
-    "id": "6a5fcafbcad4a6cf44211c962fcb8ba988f8b5dfba9dafff8e554df0fda019a0",
     "name": "pritunl-service",
   },
   Object {
@@ -7229,22 +3461,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:officelicensinghelper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OfficeLicensingHelper",
-          "id": "adfa94b3703778f1370c29b59fbdcc641ebb72a01ae8263de6f44ff9d0a0f062",
-          "sizeInByte": 4180192,
-          "version": null,
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OfficeLicensingHelper",
-    "id": "adfa94b3703778f1370c29b59fbdcc641ebb72a01ae8263de6f44ff9d0a0f062",
     "name": "officelicensinghelper",
   },
   Object {
@@ -7252,22 +3472,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:helpertool",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "HelperTool",
-          "id": "3090a4c2b1b74b3199d4fb8492399f8e7b60a9edbabc22efe62ae02a40ecbd26",
-          "sizeInByte": 4349104,
-          "version": "4.31.21011103",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "HelperTool",
-    "id": "3090a4c2b1b74b3199d4fb8492399f8e7b60a9edbabc22efe62ae02a40ecbd26",
     "name": "helpertool",
   },
   Object {
@@ -7275,22 +3483,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:com.vmware.carbonblack.cloud.ui",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "com.vmware.carbonblack.cloud.ui",
-          "id": "025b9e9e4bfe165f3f68df1f2f760bea983ecc3c66d491ce3a5504a9512c827c",
-          "sizeInByte": 7473552,
-          "version": "3.5.1.19",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "com.vmware.carbonblack.cloud.ui",
-    "id": "025b9e9e4bfe165f3f68df1f2f760bea983ecc3c66d491ce3a5504a9512c827c",
     "name": "com.vmware.carbonblack.cloud.ui",
   },
   Object {
@@ -7298,22 +3494,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:standaloneupdater",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "StandaloneUpdater",
-          "id": "9da63dc807fe0a4e2ec0828a505417e52a43021c9cd7ea00d4239e92113ab8d9",
-          "sizeInByte": 1162256,
-          "version": "20114.0607.0002",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "StandaloneUpdater",
-    "id": "9da63dc807fe0a4e2ec0828a505417e52a43021c9cd7ea00d4239e92113ab8d9",
     "name": "standaloneupdater",
   },
   Object {
@@ -7321,22 +3505,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:microsoft update assistant",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Microsoft Update Assistant",
-          "id": "d48eb960b8c594403c41a2144d80c45f2e348df25fde5e265b8f8c3e4ad70a96",
-          "sizeInByte": 5043056,
-          "version": "4.31.21011103",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Microsoft Update Assistant",
-    "id": "d48eb960b8c594403c41a2144d80c45f2e348df25fde5e265b8f8c3e4ad70a96",
     "name": "microsoft update assistant",
   },
   Object {
@@ -7344,22 +3516,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:comp portal",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Comp Portal",
-          "id": "76bde6e244886dc05e6eb3fc78c4b3b90237fc499e8d66d80c3c096b738eeddc",
-          "sizeInByte": 0,
-          "version": "4.13.0(52.2102042.000)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Comp Portal",
-    "id": "76bde6e244886dc05e6eb3fc78c4b3b90237fc499e8d66d80c3c096b738eeddc",
     "name": "comp portal",
   },
   Object {
@@ -7367,22 +3527,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:gre vocabulary flashcards",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "GRE Vocabulary Flashcards",
-          "id": "e4196ca23f72b70705494ce608f043fe2d83d0f6cefabb8870b783022acea951",
-          "sizeInByte": 0,
-          "version": "314(314.0.0.0)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "GRE Vocabulary Flashcards",
-    "id": "e4196ca23f72b70705494ce608f043fe2d83d0f6cefabb8870b783022acea951",
     "name": "gre vocabulary flashcards",
   },
   Object {
@@ -7390,22 +3538,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:youtube",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "YouTube",
-          "id": "3622a8ac5259c0599e8709777ee014f520ea0885a930e4e0b524a1833cbfaa4e",
-          "sizeInByte": 0,
-          "version": "15.49.4",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "YouTube",
-    "id": "3622a8ac5259c0599e8709777ee014f520ea0885a930e4e0b524a1833cbfaa4e",
     "name": "youtube",
   },
   Object {
@@ -7413,22 +3549,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:snapchat",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Snapchat",
-          "id": "b5fd37cf9fea9887af64b8bdc8fe084b7261c693dfff57296eaead0b1b905132",
-          "sizeInByte": 0,
-          "version": "11.8.1(11.8.1.33)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Snapchat",
-    "id": "b5fd37cf9fea9887af64b8bdc8fe084b7261c693dfff57296eaead0b1b905132",
     "name": "snapchat",
   },
   Object {
@@ -7436,22 +3560,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mindbody",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MINDBODY",
-          "id": "a4ef7ca5d1c1c1495161f880aebbf32f3f714e484981ef6e2cc84b44abce9ced",
-          "sizeInByte": 0,
-          "version": "7.4.2(10383)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MINDBODY",
-    "id": "a4ef7ca5d1c1c1495161f880aebbf32f3f714e484981ef6e2cc84b44abce9ced",
     "name": "mindbody",
   },
   Object {
@@ -7459,22 +3571,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:myfitnesspal",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MyFitnessPal",
-          "id": "8f072f8226672fd973bad59a58834a8eb164a2eeca3c7121d5548c80c6a80626",
-          "sizeInByte": 0,
-          "version": "20.24.6(33652)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MyFitnessPal",
-    "id": "8f072f8226672fd973bad59a58834a8eb164a2eeca3c7121d5548c80c6a80626",
     "name": "myfitnesspal",
   },
   Object {
@@ -7482,22 +3582,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:frontier",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Frontier",
-          "id": "92d502f6f1eafa0c76417c8fcb460ebadeecd4c4bc6f096928a4275adcc2026c",
-          "sizeInByte": 0,
-          "version": "1.9.2(2)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Frontier",
-    "id": "92d502f6f1eafa0c76417c8fcb460ebadeecd4c4bc6f096928a4275adcc2026c",
     "name": "frontier",
   },
   Object {
@@ -7505,22 +3593,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:groupon",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Groupon",
-          "id": "2aef8d7d5df278cbf1d83cee34f66c56475beafc965ab2ad31017aa452f7aef5",
-          "sizeInByte": 0,
-          "version": "20.19(312881)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Groupon",
-    "id": "2aef8d7d5df278cbf1d83cee34f66c56475beafc965ab2ad31017aa452f7aef5",
     "name": "groupon",
   },
   Object {
@@ -7528,22 +3604,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:authenticator",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Authenticator",
-          "id": "7ad47a08d35d15891e32a49d0e354eef887875decdfd5e3616a048c26c455abe",
-          "sizeInByte": 0,
-          "version": "3.1.4401",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Authenticator",
-    "id": "7ad47a08d35d15891e32a49d0e354eef887875decdfd5e3616a048c26c455abe",
     "name": "authenticator",
   },
   Object {
@@ -7551,22 +3615,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:drive",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Drive",
-          "id": "d83af102e19e55c7fa566d2fd0391213df01dbf0ad761638420296a9400905fb",
-          "sizeInByte": 0,
-          "version": "4.2020.48302",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Drive",
-    "id": "d83af102e19e55c7fa566d2fd0391213df01dbf0ad761638420296a9400905fb",
     "name": "drive",
   },
   Object {
@@ -7574,22 +3626,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:myq",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "myQ",
-          "id": "e77e6e85af0f8d0a4685d5131a8bca2e252983f8076fce9e8d41ecb159d4ca81",
-          "sizeInByte": 0,
-          "version": "5.170.0(170.0.23226)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "myQ",
-    "id": "e77e6e85af0f8d0a4685d5131a8bca2e252983f8076fce9e8d41ecb159d4ca81",
     "name": "myq",
   },
   Object {
@@ -7597,22 +3637,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:sudoku.com",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Sudoku.com",
-          "id": "b94149b3806c24ea347e9e0d42e057f3bffc0384099c77ef86e84946638c3ae0",
-          "sizeInByte": 0,
-          "version": "3.8.0(38003)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Sudoku.com",
-    "id": "b94149b3806c24ea347e9e0d42e057f3bffc0384099c77ef86e84946638c3ae0",
     "name": "sudoku.com",
   },
   Object {
@@ -7620,22 +3648,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:itunes u",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "iTunes U",
-          "id": "5bd8fbfdbff5364922c1e2861144f1a4469da9e1f8778e14a510fae219e3fb85",
-          "sizeInByte": 0,
-          "version": "3.8(2525)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "iTunes U",
-    "id": "5bd8fbfdbff5364922c1e2861144f1a4469da9e1f8778e14a510fae219e3fb85",
     "name": "itunes u",
   },
   Object {
@@ -7643,22 +3659,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:gogo entertainment",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Gogo Entertainment",
-          "id": "39e1b7dfe1e041aa5ec3997c594c35dbc5307ad0f8ac917c724818a2eae080cf",
-          "sizeInByte": 0,
-          "version": "56(1.8.0.1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Gogo Entertainment",
-    "id": "39e1b7dfe1e041aa5ec3997c594c35dbc5307ad0f8ac917c724818a2eae080cf",
     "name": "gogo entertainment",
   },
   Object {
@@ -7666,22 +3670,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:empower",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Empower",
-          "id": "45e0d91f0b8fba26f83f6d5a4c7d383bf125f617e5e0882a37fd8a18a3c13732",
-          "sizeInByte": 0,
-          "version": "1.7.2(1.2.0)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Empower",
-    "id": "45e0d91f0b8fba26f83f6d5a4c7d383bf125f617e5e0882a37fd8a18a3c13732",
     "name": "empower",
   },
   Object {
@@ -7689,22 +3681,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:linkedin",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "LinkedIn",
-          "id": "06f78faddbe4d5de149bf33b0e6cc3441be6061645f6ea53d004394048908ca6",
-          "sizeInByte": 0,
-          "version": "2020.12.14(9.16.4096.5)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "LinkedIn",
-    "id": "06f78faddbe4d5de149bf33b0e6cc3441be6061645f6ea53d004394048908ca6",
     "name": "linkedin",
   },
   Object {
@@ -7712,22 +3692,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:audible",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Audible",
-          "id": "ef8a9f78dcd65e85a32539dcc93317a473d89e45375f5b628ddc2965622597fe",
-          "sizeInByte": 0,
-          "version": "3.38.2(652)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Audible",
-    "id": "ef8a9f78dcd65e85a32539dcc93317a473d89e45375f5b628ddc2965622597fe",
     "name": "audible",
   },
   Object {
@@ -7735,22 +3703,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:word",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Word",
-          "id": "ff59fd727ae0c4aa81fcd5df84d46afd941bf16ab47fcc1c59339199115afc83",
-          "sizeInByte": 0,
-          "version": "2.44(2.44.20121101)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Word",
-    "id": "ff59fd727ae0c4aa81fcd5df84d46afd941bf16ab47fcc1c59339199115afc83",
     "name": "word",
   },
   Object {
@@ -7758,22 +3714,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:hopper",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Hopper",
-          "id": "743fb2c7fa26a32fbd2d158ced5069062b9a206f0f9c673b444d331bd48f4e51",
-          "sizeInByte": 0,
-          "version": "6.50.0(13941)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Hopper",
-    "id": "743fb2c7fa26a32fbd2d158ced5069062b9a206f0f9c673b444d331bd48f4e51",
     "name": "hopper",
   },
   Object {
@@ -7781,22 +3725,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:cash app",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Cash App",
-          "id": "4ec6c3a3961faf32ff4d0b1f107c4043d672efc7fa668d3ca3a69dee285f81aa",
-          "sizeInByte": 0,
-          "version": "3.29(3290039)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Cash App",
-    "id": "4ec6c3a3961faf32ff4d0b1f107c4043d672efc7fa668d3ca3a69dee285f81aa",
     "name": "cash app",
   },
   Object {
@@ -7804,22 +3736,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:american",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "American",
-          "id": "3e32060f0e0cd88b3815e5c164420408d0a303a36645f65ebe6e4e8ea656c3ba",
-          "sizeInByte": 0,
-          "version": "2020.20(2)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "American",
-    "id": "3e32060f0e0cd88b3815e5c164420408d0a303a36645f65ebe6e4e8ea656c3ba",
     "name": "american",
   },
   Object {
@@ -7827,22 +3747,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:paypal",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PayPal",
-          "id": "f909a4af09cc36f52a8656d6396aa2280dca3946db75ee0d13042ade2cac37a2",
-          "sizeInByte": 0,
-          "version": "7.35.0(605)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PayPal",
-    "id": "f909a4af09cc36f52a8656d6396aa2280dca3946db75ee0d13042ade2cac37a2",
     "name": "paypal",
   },
   Object {
@@ -7850,22 +3758,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:google maps",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Google Maps",
-          "id": "dedc87b6c0e8ffc4aeffe389cce6985950d493ad239e3bdaf446079d8f8841e4",
-          "sizeInByte": 0,
-          "version": "5.58.0(5.58.3)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Google Maps",
-    "id": "dedc87b6c0e8ffc4aeffe389cce6985950d493ad239e3bdaf446079d8f8841e4",
     "name": "google maps",
   },
   Object {
@@ -7873,22 +3769,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:google photos",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Google Photos",
-          "id": "205f364d7fcc7a75a64c1235f64c093de40c304dca73a44717660f9c3b258897",
-          "sizeInByte": 0,
-          "version": "5.22.0(5.22.344906647)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Google Photos",
-    "id": "205f364d7fcc7a75a64c1235f64c093de40c304dca73a44717660f9c3b258897",
     "name": "google photos",
   },
   Object {
@@ -7896,22 +3780,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:fly delta",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Fly Delta",
-          "id": "6c35b2bafde7ecac4b539383e0e12e7001d6425c4dcc6b9c014fea65ef644f52",
-          "sizeInByte": 0,
-          "version": "5.7.1(19702)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Fly Delta",
-    "id": "6c35b2bafde7ecac4b539383e0e12e7001d6425c4dcc6b9c014fea65ef644f52",
     "name": "fly delta",
   },
   Object {
@@ -7919,22 +3791,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:lyft",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Lyft",
-          "id": "3c87e8f10c1efab30eb5601a5dc504f1ad45822286ac845619034692967b61b8",
-          "sizeInByte": 0,
-          "version": "6.62.31(6.62.31.114975789)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Lyft",
-    "id": "3c87e8f10c1efab30eb5601a5dc504f1ad45822286ac845619034692967b61b8",
     "name": "lyft",
   },
   Object {
@@ -7942,22 +3802,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:carta",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Carta",
-          "id": "dc5f2976bbed71910783ca2f54595e739d9662b2f4bc22aa4f1d1b2868b202f9",
-          "sizeInByte": 0,
-          "version": "3.21.1(24373)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Carta",
-    "id": "dc5f2976bbed71910783ca2f54595e739d9662b2f4bc22aa4f1d1b2868b202f9",
     "name": "carta",
   },
   Object {
@@ -7965,22 +3813,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:insight timer",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Insight Timer",
-          "id": "4a0940978858cf76c5f5174d0e1bef937830de19b6d5eac66d740587ee5f32c0",
-          "sizeInByte": 0,
-          "version": "15.11.8(15.11.8.2169)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Insight Timer",
-    "id": "4a0940978858cf76c5f5174d0e1bef937830de19b6d5eac66d740587ee5f32c0",
     "name": "insight timer",
   },
   Object {
@@ -7988,22 +3824,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:chrome",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Chrome",
-          "id": "a293e7bd32aacdd7ba4891911fa343a39596a00d4847f0f344cabc91811ebfb8",
-          "sizeInByte": 0,
-          "version": "87.4280.77(86.0.4240.87077)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Chrome",
-    "id": "a293e7bd32aacdd7ba4891911fa343a39596a00d4847f0f344cabc91811ebfb8",
     "name": "chrome",
   },
   Object {
@@ -8011,22 +3835,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:sheets",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Sheets",
-          "id": "7049dcd7e39470d98c7dbccb0074ab7f393d29acffc3c36d152d80c4006f7c1f",
-          "sizeInByte": 0,
-          "version": "1.2020.47204",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Sheets",
-    "id": "7049dcd7e39470d98c7dbccb0074ab7f393d29acffc3c36d152d80c4006f7c1f",
     "name": "sheets",
   },
   Object {
@@ -8034,22 +3846,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:opentable",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OpenTable",
-          "id": "51a5f0fbca7f9844dd4bfd9782484bace094ecfc579580c25454757bf8062da8",
-          "sizeInByte": 0,
-          "version": "14.5.1(14.5.1.2)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OpenTable",
-    "id": "51a5f0fbca7f9844dd4bfd9782484bace094ecfc579580c25454757bf8062da8",
     "name": "opentable",
   },
   Object {
@@ -8057,22 +3857,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:wallet",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Wallet",
-          "id": "48555698df9e159c3eb6121e0e4d702ec168ecc3273fa83a54327d48cc5f5210",
-          "sizeInByte": 0,
-          "version": "3.14.0(2018031503)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Wallet",
-    "id": "48555698df9e159c3eb6121e0e4d702ec168ecc3273fa83a54327d48cc5f5210",
     "name": "wallet",
   },
   Object {
@@ -8080,22 +3868,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:onenote",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OneNote",
-          "id": "af4fa37925df4bcc1a5bd6227ac8100ace1c0d8eb8094dd51603cdecf4d8975b",
-          "sizeInByte": 0,
-          "version": "16.44.1(16044001.20121505)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OneNote",
-    "id": "af4fa37925df4bcc1a5bd6227ac8100ace1c0d8eb8094dd51603cdecf4d8975b",
     "name": "onenote",
   },
   Object {
@@ -8103,22 +3879,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:translate",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Translate",
-          "id": "a3606e8bb62ef026a96ea66a05350a8a6f79b067aa2c4eabc9dae994dbd2ba84",
-          "sizeInByte": 0,
-          "version": "6.14.59216",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Translate",
-    "id": "a3606e8bb62ef026a96ea66a05350a8a6f79b067aa2c4eabc9dae994dbd2ba84",
     "name": "translate",
   },
   Object {
@@ -8126,22 +3890,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:netflix",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Netflix",
-          "id": "c5cb64f6aa628ba702edf6a2bec93628673a1514cab0a3c63af27dcee52b0133",
-          "sizeInByte": 0,
-          "version": "13.9.0(3370)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Netflix",
-    "id": "c5cb64f6aa628ba702edf6a2bec93628673a1514cab0a3c63af27dcee52b0133",
     "name": "netflix",
   },
   Object {
@@ -8149,22 +3901,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:wells fargo",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Wells Fargo",
-          "id": "16cb567ec73776bf5d444438fe79fe2e89d5771437c7ae0252d37516d18bd2d7",
-          "sizeInByte": 0,
-          "version": "3.272(16)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Wells Fargo",
-    "id": "16cb567ec73776bf5d444438fe79fe2e89d5771437c7ae0252d37516d18bd2d7",
     "name": "wells fargo",
   },
   Object {
@@ -8172,22 +3912,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:nm",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "NM",
-          "id": "4d3ea0a38adc30dd001e138f7ee2c363d133363dcc574d36fd8ce7be1effecf0",
-          "sizeInByte": 0,
-          "version": "3.1.0(7761)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "NM",
-    "id": "4d3ea0a38adc30dd001e138f7ee2c363d133363dcc574d36fd8ce7be1effecf0",
     "name": "nm",
   },
   Object {
@@ -8195,22 +3923,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:hue",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Hue",
-          "id": "fee58a2c8e2d29afd3670e003ff3fe280a5424e64f45104f5b5d19ac66db2c0f",
-          "sizeInByte": 0,
-          "version": "3.45.0(11168)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Hue",
-    "id": "fee58a2c8e2d29afd3670e003ff3fe280a5424e64f45104f5b5d19ac66db2c0f",
     "name": "hue",
   },
   Object {
@@ -8218,22 +3934,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:powerpoint",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PowerPoint",
-          "id": "f473ef89ab31dacb66ccc587ef988586b6cda0e53396ccb1e686f88bff807f7e",
-          "sizeInByte": 0,
-          "version": "2.44(2.44.20121101)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PowerPoint",
-    "id": "f473ef89ab31dacb66ccc587ef988586b6cda0e53396ccb1e686f88bff807f7e",
     "name": "powerpoint",
   },
   Object {
@@ -8241,22 +3945,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mcdonald's",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "McDonald's",
-          "id": "d1d8226acec17c77c24d3c94f26045d3564b1a9f8e909b9f3336745167f1c33c",
-          "sizeInByte": 0,
-          "version": "6.12.0(363)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "McDonald's",
-    "id": "d1d8226acec17c77c24d3c94f26045d3564b1a9f8e909b9f3336745167f1c33c",
     "name": "mcdonald's",
   },
   Object {
@@ -8264,22 +3956,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:splitwise",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Splitwise",
-          "id": "2433ed3f7f37126ecda984412d1b53621f2d8471e6d3c49e5f7cb023c476678e",
-          "sizeInByte": 0,
-          "version": "5.3.0(552)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Splitwise",
-    "id": "2433ed3f7f37126ecda984412d1b53621f2d8471e6d3c49e5f7cb023c476678e",
     "name": "splitwise",
   },
   Object {
@@ -8287,22 +3967,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:fandango",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Fandango",
-          "id": "190a9ab4267a5453c86fdf9237e1544e0cad22784674220453c35e6715439c6b",
-          "sizeInByte": 0,
-          "version": "12.7(211)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Fandango",
-    "id": "190a9ab4267a5453c86fdf9237e1544e0cad22784674220453c35e6715439c6b",
     "name": "fandango",
   },
   Object {
@@ -8310,22 +3978,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:huemote",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Huemote",
-          "id": "9c08705205ed52eccc7231fbb13ae6e1289d838976166b5d5e38c788c4863c47",
-          "sizeInByte": 0,
-          "version": "1.1.3(123)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Huemote",
-    "id": "9c08705205ed52eccc7231fbb13ae6e1289d838976166b5d5e38c788c4863c47",
     "name": "huemote",
   },
   Object {
@@ -8333,22 +3989,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:fantasy",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Fantasy",
-          "id": "aa6a8dcaf7cbf2d2a095238af4fcb7cb47f688d8a1bb3032715e7ebae3ddc186",
-          "sizeInByte": 0,
-          "version": "7.6.0(732)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Fantasy",
-    "id": "aa6a8dcaf7cbf2d2a095238af4fcb7cb47f688d8a1bb3032715e7ebae3ddc186",
     "name": "fantasy",
   },
   Object {
@@ -8356,22 +4000,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:tiny scanner",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Tiny Scanner",
-          "id": "55291b140992a38dfcf6e9877e2bfe9edea76804905ac5165a41cf4a928f178b",
-          "sizeInByte": 0,
-          "version": "6.1.4(6140)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Tiny Scanner",
-    "id": "55291b140992a38dfcf6e9877e2bfe9edea76804905ac5165a41cf4a928f178b",
     "name": "tiny scanner",
   },
   Object {
@@ -8379,22 +4011,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:docs",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Docs",
-          "id": "ee7e4fe7b8cab60269e7fe2dca4e8fc3b45bca32136a84cccd335b960173d564",
-          "sizeInByte": 0,
-          "version": "1.2020.47204",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Docs",
-    "id": "ee7e4fe7b8cab60269e7fe2dca4e8fc3b45bca32136a84cccd335b960173d564",
     "name": "docs",
   },
   Object {
@@ -8402,22 +4022,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:authy",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Authy",
-          "id": "b66942449f0b867385932041ebd8b8598ede1657e19687874b969a0e699bf506",
-          "sizeInByte": 0,
-          "version": "24.4.4(20201202.1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Authy",
-    "id": "b66942449f0b867385932041ebd8b8598ede1657e19687874b969a0e699bf506",
     "name": "authy",
   },
   Object {
@@ -8425,22 +4033,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:messenger",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Messenger",
-          "id": "3c88ec08bd29e6504f8a85ddf927a0196472866da98813414afe53bc7d7f28df",
-          "sizeInByte": 0,
-          "version": "294.0(262406393)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Messenger",
-    "id": "3c88ec08bd29e6504f8a85ddf927a0196472866da98813414afe53bc7d7f28df",
     "name": "messenger",
   },
   Object {
@@ -8448,22 +4044,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:expensify",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Expensify",
-          "id": "fb0e1ddeef1a0c03e25a54c6b874b992703e3b40880020239c33e60182a60427",
-          "sizeInByte": 0,
-          "version": "8.5.20(8.5.20.0)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Expensify",
-    "id": "fb0e1ddeef1a0c03e25a54c6b874b992703e3b40880020239c33e60182a60427",
     "name": "expensify",
   },
   Object {
@@ -8471,22 +4055,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:deepblu",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Deepblu",
-          "id": "146306866ce4bd18b400cce271218ebf0746ad2b48ea370ad1a4d94f239faf26",
-          "sizeInByte": 0,
-          "version": "3.5.6(1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Deepblu",
-    "id": "146306866ce4bd18b400cce271218ebf0746ad2b48ea370ad1a4d94f239faf26",
     "name": "deepblu",
   },
   Object {
@@ -8494,22 +4066,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:venmo",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Venmo",
-          "id": "022f17c0c6a9e18f30e7055c778deb6ca88a1465266b1b9c4a6bd0870b0b150d",
-          "sizeInByte": 0,
-          "version": "8.12.1(27524)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Venmo",
-    "id": "022f17c0c6a9e18f30e7055c778deb6ca88a1465266b1b9c4a6bd0870b0b150d",
     "name": "venmo",
   },
   Object {
@@ -8517,22 +4077,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:chess tactics",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Chess Tactics",
-          "id": "0efb885c1113dfad920146c8d37ed3acf563a809ac9adbc00d39388ead07d70d",
-          "sizeInByte": 0,
-          "version": "2.03(31)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Chess Tactics",
-    "id": "0efb885c1113dfad920146c8d37ed3acf563a809ac9adbc00d39388ead07d70d",
     "name": "chess tactics",
   },
   Object {
@@ -8540,22 +4088,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:groupme",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "GroupMe",
-          "id": "6fdb7138385c3ea001f2d6bf40809f1d5c8d6f194c439b6094e27320d6bfcdf3",
-          "sizeInByte": 0,
-          "version": "5.45.5(5.45.5.1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "GroupMe",
-    "id": "6fdb7138385c3ea001f2d6bf40809f1d5c8d6f194c439b6094e27320d6bfcdf3",
     "name": "groupme",
   },
   Object {
@@ -8563,22 +4099,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:bandsintown",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Bandsintown",
-          "id": "708e77e4e2c416a32f705613aea5406089f467a5f0f3c85f0bc3f452a0344fa4",
-          "sizeInByte": 0,
-          "version": "8.2.1(3459)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Bandsintown",
-    "id": "708e77e4e2c416a32f705613aea5406089f467a5f0f3c85f0bc3f452a0344fa4",
     "name": "bandsintown",
   },
   Object {
@@ -8586,22 +4110,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:orangetheory",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Orangetheory",
-          "id": "f2c0cb3320beab1cb99834e054f22862839fc7e8182038535965c5e09a6f16d6",
-          "sizeInByte": 0,
-          "version": "4.1.0(3268)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Orangetheory",
-    "id": "f2c0cb3320beab1cb99834e054f22862839fc7e8182038535965c5e09a6f16d6",
     "name": "orangetheory",
   },
   Object {
@@ -8609,22 +4121,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:yelp",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Yelp",
-          "id": "4cb1b7ca5892b06331ea1b00ec2a2e4a26125802d2213e7742b1c2e828ece9c2",
-          "sizeInByte": 0,
-          "version": "12.76.0(12.76.0.28067)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Yelp",
-    "id": "4cb1b7ca5892b06331ea1b00ec2a2e4a26125802d2213e7742b1c2e828ece9c2",
     "name": "yelp",
   },
   Object {
@@ -8632,22 +4132,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:edge",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Edge",
-          "id": "8823809861e76536a689e3f8f773f4808b8b96800eb3331a5db5f31a18896ea0",
-          "sizeInByte": 0,
-          "version": "46.1.2",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Edge",
-    "id": "8823809861e76536a689e3f8f773f4808b8b96800eb3331a5db5f31a18896ea0",
     "name": "edge",
   },
   Object {
@@ -8655,22 +4143,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:padi library",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "PADI Library",
-          "id": "e0665b72c9fec03b520404d6ef9e400cf251a1e8d86f944a4546d80869d9a808",
-          "sizeInByte": 0,
-          "version": "3.0.10(3.0.10.1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "PADI Library",
-    "id": "e0665b72c9fec03b520404d6ef9e400cf251a1e8d86f944a4546d80869d9a808",
     "name": "padi library",
   },
   Object {
@@ -8678,22 +4154,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:pancheros",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Pancheros",
-          "id": "159a8b3f7de0e48debf1e769845f2df98b4bf9032644595ce3a841508d044b26",
-          "sizeInByte": 0,
-          "version": "2.3(4)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Pancheros",
-    "id": "159a8b3f7de0e48debf1e769845f2df98b4bf9032644595ce3a841508d044b26",
     "name": "pancheros",
   },
   Object {
@@ -8701,22 +4165,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:apple store",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Apple Store",
-          "id": "9338f886cc5220be3ae1a4f6e2e77285f874c4cf8a5c846a495e7b7d66b26d8b",
-          "sizeInByte": 0,
-          "version": "505000(5.5.0.0480)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Apple Store",
-    "id": "9338f886cc5220be3ae1a4f6e2e77285f874c4cf8a5c846a495e7b7d66b26d8b",
     "name": "apple store",
   },
   Object {
@@ -8724,22 +4176,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:spirit",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Spirit",
-          "id": "e56be69406bc666928a54f5e63b2111cd99131a758168415651125d483d1230e",
-          "sizeInByte": 0,
-          "version": "1.5.8(182)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Spirit",
-    "id": "e56be69406bc666928a54f5e63b2111cd99131a758168415651125d483d1230e",
     "name": "spirit",
   },
   Object {
@@ -8747,22 +4187,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:anova",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Anova",
-          "id": "2d562a0ddf768d04a4446ae4a87383aa42f1894265d79d88db138f7109211d85",
-          "sizeInByte": 0,
-          "version": "3.2.14(1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Anova",
-    "id": "2d562a0ddf768d04a4446ae4a87383aa42f1894265d79d88db138f7109211d85",
     "name": "anova",
   },
   Object {
@@ -8770,22 +4198,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:capital one",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Capital One",
-          "id": "dd9f269cc57cc5f45e4c51780f826c9876400248545ae6d80cfd7beac3d52a52",
-          "sizeInByte": 0,
-          "version": "5.75.2(2)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Capital One",
-    "id": "dd9f269cc57cc5f45e4c51780f826c9876400248545ae6d80cfd7beac3d52a52",
     "name": "capital one",
   },
   Object {
@@ -8793,22 +4209,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:onswitch",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "OnSwitch",
-          "id": "0838f312698cbc6a8f938c399d314101934058082fa1098cdc260aadacb65bfb",
-          "sizeInByte": 0,
-          "version": "3.0.21(3.0.21.2)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "OnSwitch",
-    "id": "0838f312698cbc6a8f938c399d314101934058082fa1098cdc260aadacb65bfb",
     "name": "onswitch",
   },
   Object {
@@ -8816,22 +4220,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:netbenefits",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "NetBenefits",
-          "id": "a2c773efe6134531d34215b0ea72e5e8f1fd16c48e8e2d08d76e832dee8daf19",
-          "sizeInByte": 0,
-          "version": "3.15.0(3.15.1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "NetBenefits",
-    "id": "a2c773efe6134531d34215b0ea72e5e8f1fd16c48e8e2d08d76e832dee8daf19",
     "name": "netbenefits",
   },
   Object {
@@ -8839,22 +4231,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mobile pass",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Mobile Pass",
-          "id": "4dc2c74312b4b35ebf8856089bb2257ac9c32ad1c3e69998b8e195d0705ee3d3",
-          "sizeInByte": 0,
-          "version": "3.11.0(1608109362)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Mobile Pass",
-    "id": "4dc2c74312b4b35ebf8856089bb2257ac9c32ad1c3e69998b8e195d0705ee3d3",
     "name": "mobile pass",
   },
   Object {
@@ -8862,22 +4242,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:zen planner",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Zen Planner",
-          "id": "4879d778cb471aed72418ad037e8321354ace93909d949469a0ebe7a2002b092",
-          "sizeInByte": 0,
-          "version": "2.4.32",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Zen Planner",
-    "id": "4879d778cb471aed72418ad037e8321354ace93909d949469a0ebe7a2002b092",
     "name": "zen planner",
   },
   Object {
@@ -8885,22 +4253,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:scanner app",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Scanner App",
-          "id": "782d4ee782ef2f223c1b33fa3bb13d1cde7bc5cd0cdf1a2acfc84eb5704c1012",
-          "sizeInByte": 0,
-          "version": "4.3(4.3.7)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Scanner App",
-    "id": "782d4ee782ef2f223c1b33fa3bb13d1cde7bc5cd0cdf1a2acfc84eb5704c1012",
     "name": "scanner app",
   },
   Object {
@@ -8908,22 +4264,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:bitmoji",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Bitmoji",
-          "id": "4a1ed1dc4deab77ca364150d33081742b9d6e1d103cf0cbfe4be9062dc89d680",
-          "sizeInByte": 0,
-          "version": "11.7.2(11.7.2.788)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Bitmoji",
-    "id": "4a1ed1dc4deab77ca364150d33081742b9d6e1d103cf0cbfe4be9062dc89d680",
     "name": "bitmoji",
   },
   Object {
@@ -8931,22 +4275,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:uber",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Uber",
-          "id": "6622f543dfdffef7bb34dcabda42fa3e812a34318b37516606765e0fe7c846ba",
-          "sizeInByte": 0,
-          "version": "3.434.10005",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Uber",
-    "id": "6622f543dfdffef7bb34dcabda42fa3e812a34318b37516606765e0fe7c846ba",
     "name": "uber",
   },
   Object {
@@ -8954,22 +4286,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:cebu pacific",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Cebu Pacific",
-          "id": "d9107dcb41a6c519d9cd8eb9e3310caf68a64adcbc2d0163d45a5e6507d38cbf",
-          "sizeInByte": 0,
-          "version": "2.58.0(161222)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Cebu Pacific",
-    "id": "d9107dcb41a6c519d9cd8eb9e3310caf68a64adcbc2d0163d45a5e6507d38cbf",
     "name": "cebu pacific",
   },
   Object {
@@ -8977,22 +4297,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:united",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "United",
-          "id": "508810c20936a821e96d24f5f96f3b12e9e5efa63c572f719726c87da5d7cb4d",
-          "sizeInByte": 0,
-          "version": "4.1.8(4.1.8.1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "United",
-    "id": "508810c20936a821e96d24f5f96f3b12e9e5efa63c572f719726c87da5d7cb4d",
     "name": "united",
   },
   Object {
@@ -9000,22 +4308,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:excel",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Excel",
-          "id": "cbd625fdf671fe7408627bf188089e75d295c02f8aad2d94207f7da27f4f0369",
-          "sizeInByte": 0,
-          "version": "2.44(2.44.20121101)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Excel",
-    "id": "cbd625fdf671fe7408627bf188089e75d295c02f8aad2d94207f7da27f4f0369",
     "name": "excel",
   },
   Object {
@@ -9023,22 +4319,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:among us",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Among Us",
-          "id": "d20a289fffe662d468604e78b3d668830f7b7580ad168213e357472351d7d3a6",
-          "sizeInByte": 0,
-          "version": "2020.11.17(1)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Among Us",
-    "id": "d20a289fffe662d468604e78b3d668830f7b7580ad168213e357472351d7d3a6",
     "name": "among us",
   },
   Object {
@@ -9046,22 +4330,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:mychart",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "MyChart",
-          "id": "b79f8a9762e5dfe03f1cf589ff49cc1c6adec4befcfdf083a02fdda5e7b60139",
-          "sizeInByte": 0,
-          "version": "9.5.5",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "MyChart",
-    "id": "b79f8a9762e5dfe03f1cf589ff49cc1c6adec4befcfdf083a02fdda5e7b60139",
     "name": "mychart",
   },
   Object {
@@ -9069,22 +4341,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:zoom",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Zoom",
-          "id": "72d664599f8db68d49a6d32445ac8064927162ab62cfbd9ddcb2c8f7b75373b4",
-          "sizeInByte": 0,
-          "version": "5.4.6(59285.1207)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Zoom",
-    "id": "72d664599f8db68d49a6d32445ac8064927162ab62cfbd9ddcb2c8f7b75373b4",
     "name": "zoom",
   },
   Object {
@@ -9092,22 +4352,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:google calendar",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Google Calendar",
-          "id": "21af32b055e70cd1db3fe1c7dde7f654a1411c1a8e779350320f88217951a151",
-          "sizeInByte": 0,
-          "version": "20.45.0(20.45.0.52801200)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Google Calendar",
-    "id": "21af32b055e70cd1db3fe1c7dde7f654a1411c1a8e779350320f88217951a151",
     "name": "google calendar",
   },
   Object {
@@ -9115,22 +4363,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:discord",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Discord",
-          "id": "89a12d9682718df9de80432b85e4083c3074074032fd2d61467b787a45003ab1",
-          "sizeInByte": 0,
-          "version": "53.0(23255)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Discord",
-    "id": "89a12d9682718df9de80432b85e4083c3074074032fd2d61467b787a45003ab1",
     "name": "discord",
   },
   Object {
@@ -9138,22 +4374,10 @@ Array [
       "Application",
     ],
     "_key": "IntuneDetected:trello",
-    "_rawData": Array [
-      Object {
-        "name": "default",
-        "rawData": Object {
-          "deviceCount": 0,
-          "displayName": "Trello",
-          "id": "3523e03a4baec626ed676703a91b34fa01ab17fe23d1f87e9610b53a10d8676f",
-          "sizeInByte": 0,
-          "version": "2020.16.1(20201214.195337)",
-        },
-      },
-    ],
+    "_rawData": Array [],
     "_type": "intune_detected_application",
     "createdOn": undefined,
     "displayName": "Trello",
-    "id": "3523e03a4baec626ed676703a91b34fa01ab17fe23d1f87e9610b53a10d8676f",
     "name": "trello",
   },
 ]

--- a/src/steps/intune/steps/applications/converters.ts
+++ b/src/steps/intune/steps/applications/converters.ts
@@ -75,7 +75,7 @@ export function createDetectedApplicationEntity(
 ): Entity {
   return createIntegrationEntity({
     entityData: {
-      source: detectedApp,
+      source: {},
       assign: {
         _class: entities.DETECTED_APPLICATION._class,
         _type: entities.DETECTED_APPLICATION._type,

--- a/src/steps/intune/steps/applications/index.ts
+++ b/src/steps/intune/steps/applications/index.ts
@@ -119,12 +119,13 @@ export async function fetchDetectedApplications(
 
             const version = detectedApp.version ?? UNVERSIONED;
 
-            const deviceInstalledDetectedAppKey = `${generateRelationshipKey(
-              relationships.MULTI_DEVICE_INSTALLED_DETECTED_APPLICATION[0]
-                ._class,
-              deviceEntity._key,
-              detectedAppEntity._key,
-            )}|${detectedApp.id}`;
+            const deviceInstalledDetectedAppKey =
+              generateRelationshipKey(
+                relationships.MULTI_DEVICE_INSTALLED_DETECTED_APPLICATION[0]
+                  ._class,
+                deviceEntity._key,
+                detectedAppEntity._key,
+              ) + `|${detectedApp.id}`;
 
             if (await jobState.hasKey(deviceInstalledDetectedAppKey)) {
               logger.warn(


### PR DESCRIPTION
# Description

This PR fixes a duplicate key error causing sync jobs to fail.

The root cause of this error likely comes from the need for Lambda's to be idempotent. Occasionally, lambdas can be re-triggered with the same payload. This seems to happen when certain payloads have large `raw_data`s.

## Fixes:
- `raw_data` has been removed from `detectedApplication` entities
- additional duplicate key check has been added to `fetchDetectedApplications` step

