### PR TITLE
[INT-3394] Fix Fetch Error

### DIFF
--- a/src/ms-graph/client.ts
+++ b/src/ms-graph/client.ts
@@ -19,12 +19,19 @@ import 'isomorphic-unfetch';
 import { toArray } from '../utils/toArray';
 
 import { ClientConfig } from './types';
+import { isRetryable } from './utils';
 
 export type QueryParams = string | { [key: string]: string | number };
 
 interface GraphClientResponse<T> {
   value: T[];
   '@odata.nextLink'?: string;
+}
+
+interface ExecuteIterationParams<T> {
+  resourceUrl: string;
+  query?: QueryParams;
+  callback: (each: T) => Promise<void> | void;
 }
 
 /**
@@ -138,22 +145,19 @@ export class GraphClient {
       this.handleApiError(error, url);
     }
   }
-
   // Not using PageIterator because it doesn't allow async callback
   /**
    * Iterate resources. 401 Unauthorized, 403 Forbidden, and 404 Not Found
    * responses are considered empty collections. Other API errors will be
    * thrown.
    */
-  protected async iterateResources<T>({
+  public async iterateResources<T>({
     resourceUrl,
     query,
     callback,
-  }: {
-    resourceUrl: string;
-    query?: QueryParams;
-    callback: (item: T) => void | Promise<void>;
-  }): Promise<void> {
+  }: ExecuteIterationParams<T>) {
+    // unless the caller passes an empty string
+    // nextLink should also be truthy the first run
     let nextLink: string | undefined = resourceUrl;
     let retries = 0;
     let response: GraphClientResponse<T> | undefined;
@@ -164,13 +168,7 @@ export class GraphClient {
           query,
         });
       } catch (err) {
-        if (
-          err.message ===
-            'CompactToken parsing failed with error code: 80049217' &&
-          nextLink &&
-          retries < 5
-        ) {
-          // Retry a few times to handle sporatic timing issue with this sdk - https://github.com/OneDrive/onedrive-api-docs/issues/785
+        if (isRetryable(err, nextLink, retries)) {
           retries++;
           continue;
         } else {
@@ -178,6 +176,7 @@ export class GraphClient {
           this.handleApiError(err, resourceUrl);
         }
       }
+
       if (response) {
         for (const value of response.value) {
           await callback(value);

--- a/src/ms-graph/client.ts
+++ b/src/ms-graph/client.ts
@@ -168,7 +168,7 @@ export class GraphClient {
           query,
         });
       } catch (err) {
-        if (isRetryable(err, nextLink, retries)) {
+        if (isRetryable(err, retries)) {
           retries++;
           continue;
         } else {

--- a/src/ms-graph/client.ts
+++ b/src/ms-graph/client.ts
@@ -169,6 +169,15 @@ export class GraphClient {
         });
       } catch (err) {
         if (isRetryable(err, retries)) {
+          this.logger.info(
+            {
+              retries: retries,
+              statusCode: err.statusCode,
+              statusText: err.statusText,
+              errMessage: err.message,
+            },
+            'Retryable error occurred during API call. Retrying...',
+          );
           retries++;
           continue;
         } else {

--- a/src/ms-graph/utils.test.ts
+++ b/src/ms-graph/utils.test.ts
@@ -7,7 +7,7 @@ describe('#isRetryable', () => {
       statusCode: -1,
       statusText: 'FetchError',
     });
-    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+    expect(isRetryable(err, 0)).toBe(true);
   });
 
   test('will retry 408 errors', () => {
@@ -16,7 +16,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 408,
     });
-    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+    expect(isRetryable(err, 0)).toBe(true);
   });
 
   test('will retry 500 errors', () => {
@@ -25,7 +25,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 500,
     });
-    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+    expect(isRetryable(err, 0)).toBe(true);
   });
 
   test('will retry 502 errors', () => {
@@ -35,7 +35,7 @@ describe('#isRetryable', () => {
       statusCode: 502,
     });
 
-    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+    expect(isRetryable(err, 0)).toBe(true);
   });
 
   test('will retry compact token error', () => {
@@ -43,19 +43,7 @@ describe('#isRetryable', () => {
       'CompactToken parsing failed with error code: 80049217',
     );
 
-    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
-  });
-
-  test('will not retry if next link is empty', () => {
-    const err = new Error();
-
-    // assign a retryable code
-    Object.assign(err, {
-      statusCode: 502,
-    });
-
-    // but nextLink is empty so we shouldn't retry
-    expect(isRetryable(err, '', 0)).toBe(false);
+    expect(isRetryable(err, 0)).toBe(true);
   });
 
   test('will ot retry if already retried 5 times', () => {
@@ -66,6 +54,6 @@ describe('#isRetryable', () => {
     });
 
     // but we've already retried 5 times so we shouldn't retry
-    expect(isRetryable(err, '', 5)).toBe(false);
+    expect(isRetryable(err, 5)).toBe(false);
   });
 });

--- a/src/ms-graph/utils.test.ts
+++ b/src/ms-graph/utils.test.ts
@@ -10,6 +10,15 @@ describe('#isRetryable', () => {
     expect(isRetryable(err, 0)).toBe(true);
   });
 
+  test('will retry 400 Errors', () => {
+    const err = new Error();
+
+    Object.assign(err, {
+      statusCode: 400,
+    });
+    expect(isRetryable(err, 0)).toBe(true);
+  });
+
   test('will retry 408 errors', () => {
     const err = new Error();
 
@@ -35,6 +44,22 @@ describe('#isRetryable', () => {
       statusCode: 502,
     });
 
+    expect(isRetryable(err, 0)).toBe(true);
+  });
+
+  test('will retry 503 errors', () => {
+    const err = new Error();
+    Object.assign(err, {
+      statusCode: 503,
+    });
+    expect(isRetryable(err, 0)).toBe(true);
+  });
+
+  test('will retry 504 erorrs', () => {
+    const err = new Error();
+    Object.assign(err, {
+      statusCode: 504,
+    });
     expect(isRetryable(err, 0)).toBe(true);
   });
 

--- a/src/ms-graph/utils.test.ts
+++ b/src/ms-graph/utils.test.ts
@@ -1,4 +1,4 @@
-import { isRetryable } from './utils';
+import { isRetryable, retriesAvailable } from './utils';
 
 describe('#isRetryable', () => {
   test('will retry -1 Fetch Error', () => {
@@ -7,7 +7,7 @@ describe('#isRetryable', () => {
       statusCode: -1,
       statusText: 'FetchError',
     });
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry 400 Errors', () => {
@@ -16,7 +16,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 400,
     });
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry 408 errors', () => {
@@ -25,7 +25,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 408,
     });
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry 500 errors', () => {
@@ -34,7 +34,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 500,
     });
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry 502 errors', () => {
@@ -44,7 +44,7 @@ describe('#isRetryable', () => {
       statusCode: 502,
     });
 
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry 503 errors', () => {
@@ -52,7 +52,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 503,
     });
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry 504 erorrs', () => {
@@ -60,7 +60,7 @@ describe('#isRetryable', () => {
     Object.assign(err, {
       statusCode: 504,
     });
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
   test('will retry compact token error', () => {
@@ -68,17 +68,10 @@ describe('#isRetryable', () => {
       'CompactToken parsing failed with error code: 80049217',
     );
 
-    expect(isRetryable(err, 0)).toBe(true);
+    expect(isRetryable(err)).toBe(true);
   });
 
-  test('will ot retry if already retried 5 times', () => {
-    const err = new Error();
-    // we have a retryable status code
-    Object.assign(err, {
-      statusCode: 502,
-    });
-
-    // but we've already retried 5 times so we shouldn't retry
-    expect(isRetryable(err, 5)).toBe(false);
+  test('will not retry if already retried 5 times', () => {
+    expect(retriesAvailable(5)).toBe(false);
   });
 });

--- a/src/ms-graph/utils.test.ts
+++ b/src/ms-graph/utils.test.ts
@@ -1,0 +1,71 @@
+import { isRetryable } from './utils';
+
+describe('#isRetryable', () => {
+  test('will retry -1 Fetch Error', () => {
+    const err = new Error();
+    Object.assign(err, {
+      statusCode: -1,
+      statusText: 'FetchError',
+    });
+    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+  });
+
+  test('will retry 408 errors', () => {
+    const err = new Error();
+
+    Object.assign(err, {
+      statusCode: 408,
+    });
+    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+  });
+
+  test('will retry 500 errors', () => {
+    const err = new Error();
+
+    Object.assign(err, {
+      statusCode: 500,
+    });
+    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+  });
+
+  test('will retry 502 errors', () => {
+    const err = new Error();
+
+    Object.assign(err, {
+      statusCode: 502,
+    });
+
+    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+  });
+
+  test('will retry compact token error', () => {
+    const err = new Error(
+      'CompactToken parsing failed with error code: 80049217',
+    );
+
+    expect(isRetryable(err, 'dummy-link', 0)).toBe(true);
+  });
+
+  test('will not retry if next link is empty', () => {
+    const err = new Error();
+
+    // assign a retryable code
+    Object.assign(err, {
+      statusCode: 502,
+    });
+
+    // but nextLink is empty so we shouldn't retry
+    expect(isRetryable(err, '', 0)).toBe(false);
+  });
+
+  test('will ot retry if already retried 5 times', () => {
+    const err = new Error();
+    // we have a retryable status code
+    Object.assign(err, {
+      statusCode: 502,
+    });
+
+    // but we've already retried 5 times so we shouldn't retry
+    expect(isRetryable(err, '', 5)).toBe(false);
+  });
+});

--- a/src/ms-graph/utils.ts
+++ b/src/ms-graph/utils.ts
@@ -1,0 +1,24 @@
+export function isRetryable(
+  err: any,
+  nextLink: string,
+  retries: number,
+): boolean {
+  const retryableErrorMessages = [
+    'CompactToken parsing failed with error code: 80049217',
+  ];
+  // we can retry
+  // -1 a `FetchError` (probably connection timeout)
+  // 500 InternalSeverError
+  // 502 BadGateway, although we have seen this status code with statusText: UnknownError
+  // Others we could consider adding if necessary: 408, 503 and others
+  const retryableStatusCodes = [-1, 408, 500, 502];
+
+  // A FetchError is a connection timeout that we should retry
+  // retryable can be type boolean, "", or undefined
+  return (
+    retries < 5 &&
+    !!nextLink &&
+    (retryableErrorMessages.includes(err.message) ||
+      retryableStatusCodes.includes(err.statusCode))
+  );
+}

--- a/src/ms-graph/utils.ts
+++ b/src/ms-graph/utils.ts
@@ -1,17 +1,25 @@
 export function isRetryable(err: any, retries: number): boolean {
-  const retryableErrorMessages = [
-    'CompactToken parsing failed with error code: 80049217',
-  ];
-  // we can retry
   // -1 a `FetchError` (probably connection timeout)
+  // 400 Bad Request
+  // 408 Request Timeout
   // 500 InternalSeverError
   // 502 BadGateway, although we have seen this status code with statusText: UnknownError
+  // 503 ServiceUnavailable, haven't seen this error but is retryable
+  // 504 GatewayTimeout
   // Others we could consider adding if necessary: 408, 503 and others
-  const retryableStatusCodes = [-1, 408, 500, 502];
+  const isRetryableStatusCode = (statusCode: number): boolean => {
+    return [-1, 400, 408, 500, 502, 503, 504].includes(statusCode);
+  };
+
+  const isRetryableErrorMessage = (message: string): boolean => {
+    return ['CompactToken parsing failed with error code: 80049217'].includes(
+      message,
+    );
+  };
 
   return (
     retries < 5 &&
-    (retryableErrorMessages.includes(err.message) ||
-      retryableStatusCodes.includes(err.statusCode))
+    (isRetryableStatusCode(err.statusCode) ||
+      isRetryableErrorMessage(err.message))
   );
 }

--- a/src/ms-graph/utils.ts
+++ b/src/ms-graph/utils.ts
@@ -9,8 +9,6 @@ export function isRetryable(err: any, retries: number): boolean {
   // Others we could consider adding if necessary: 408, 503 and others
   const retryableStatusCodes = [-1, 408, 500, 502];
 
-  // A FetchError is a connection timeout that we should retry
-  // retryable can be type boolean, "", or undefined
   return (
     retries < 5 &&
     (retryableErrorMessages.includes(err.message) ||

--- a/src/ms-graph/utils.ts
+++ b/src/ms-graph/utils.ts
@@ -1,8 +1,4 @@
-export function isRetryable(
-  err: any,
-  nextLink: string,
-  retries: number,
-): boolean {
+export function isRetryable(err: any, retries: number): boolean {
   const retryableErrorMessages = [
     'CompactToken parsing failed with error code: 80049217',
   ];
@@ -17,7 +13,6 @@ export function isRetryable(
   // retryable can be type boolean, "", or undefined
   return (
     retries < 5 &&
-    !!nextLink &&
     (retryableErrorMessages.includes(err.message) ||
       retryableStatusCodes.includes(err.statusCode))
   );

--- a/src/ms-graph/utils.ts
+++ b/src/ms-graph/utils.ts
@@ -1,4 +1,4 @@
-export function isRetryable(err: any, retries: number): boolean {
+export function isRetryable(err: any): boolean {
   // -1 a `FetchError` (probably connection timeout)
   // 400 Bad Request
   // 408 Request Timeout
@@ -18,8 +18,11 @@ export function isRetryable(err: any, retries: number): boolean {
   };
 
   return (
-    retries < 5 &&
-    (isRetryableStatusCode(err.statusCode) ||
-      isRetryableErrorMessage(err.message))
+    isRetryableStatusCode(err.statusCode) ||
+    isRetryableErrorMessage(err.message)
   );
+}
+
+export function retriesAvailable(retries: number): boolean {
+  return retries < 5;
 }


### PR DESCRIPTION
# Description

The `-1 FetchError` is likely caused by a connection timeout. We can retry these errors. I've also added other `statusCodes` we can retry. The full list of retryable `statusCodes` is: **[-1, 408, 500, 502]**



