### PR TITLE
Normalize macAddress property

### DIFF
--- a/src/steps/intune/steps/devices/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/intune/steps/devices/__tests__/__snapshots__/index.test.ts.snap
@@ -107,7 +107,7 @@ Array [
     "ipAddress": undefined,
     "jailBroken": false,
     "macAddress": Array [
-      "[REDACTED]",
+      "[redacted]",
     ],
     "make": "Apple",
     "managed": true,
@@ -164,7 +164,7 @@ Array [
     "ipAddress": undefined,
     "jailBroken": true,
     "macAddress": Array [
-      "[REDACTED]",
+      "[redacted]",
     ],
     "make": "Apple",
     "managed": true,
@@ -319,7 +319,7 @@ Array [
     "ipAddress": undefined,
     "jailBroken": false,
     "macAddress": Array [
-      "[REDACTED]",
+      "[redacted]",
     ],
     "make": "Apple",
     "managed": true,
@@ -376,7 +376,7 @@ Array [
     "ipAddress": undefined,
     "jailBroken": true,
     "macAddress": Array [
-      "[REDACTED]",
+      "[redacted]",
     ],
     "make": "Apple",
     "managed": true,

--- a/src/steps/intune/steps/devices/__tests__/converters.test.ts
+++ b/src/steps/intune/steps/devices/__tests__/converters.test.ts
@@ -1,5 +1,5 @@
 import { DeviceType } from '@microsoft/microsoft-graph-types-beta';
-import { selectDeviceType } from '../converters';
+import { normalizeMacAddress, selectDeviceType } from '../converters';
 
 describe('selectDeviceType', () => {
   test('if a device is not physical, it should be typed as a server', () => {
@@ -18,5 +18,18 @@ describe('selectDeviceType', () => {
 
   test('windowsRT device type should be a user_endpoint', () => {
     expect(selectDeviceType('windowsRT', true)).toBe('user_endpoint');
+  });
+});
+
+describe('#normalizeMacAddress', () => {
+  test('macAddress is normalized', () => {
+    const macAddress = '001122AABBCC';
+    const expected = '00:11:22:aa:bb:cc';
+    expect(normalizeMacAddress(macAddress)).toBe(expected);
+  });
+  test('lowercases macAddress that are not length 12', () => {
+    const macAddress = '00:11:22:AA:BB:CC';
+    const expected = '00:11:22:aa:bb:cc';
+    expect(normalizeMacAddress(macAddress)).toBe(expected);
   });
 });

--- a/src/steps/intune/steps/devices/converters.ts
+++ b/src/steps/intune/steps/devices/converters.ts
@@ -15,6 +15,29 @@ import { entities as activeDirectoryEntities } from '../../../active-directory';
 import { entities, INTUNE_HOST_AGENT_KEY_PREFIX } from '../../constants';
 import { ManagedDeviceType, relationships } from '../../constants';
 
+export function normalizeMacAddress(macAddress: string): string {
+  // A macAddress that is length 12 should be normalized and lowercased
+  // A macAddress not of length 12 should just be lowercased
+  // (e.g. 11AA22BB33CC can be normalized, but 11:AA)
+  if (macAddress.length !== 12) {
+    return macAddress.toLowerCase();
+  }
+
+  let normalizedMacAddress =
+    macAddress.slice(0, 2) +
+    ':' +
+    macAddress.slice(2, 4) +
+    ':' +
+    macAddress.slice(4, 6) +
+    ':' +
+    macAddress.slice(6, 8) +
+    ':' +
+    macAddress.slice(8, 10) +
+    ':' +
+    macAddress.slice(10, 12);
+  return normalizedMacAddress.toLowerCase();
+}
+
 // https://docs.microsoft.com/en-us/graph/api/resources/intune-devices-manageddevice?view=graph-rest-1.0&viewFallbackFrom=graph-rest-beta
 export function createManagedDeviceEntity(
   managedDevice: ManagedDevice,

--- a/src/steps/intune/steps/devices/converters.ts
+++ b/src/steps/intune/steps/devices/converters.ts
@@ -23,7 +23,7 @@ export function normalizeMacAddress(macAddress: string): string {
     return macAddress.toLowerCase();
   }
 
-  let normalizedMacAddress =
+  const normalizedMacAddress =
     macAddress.slice(0, 2) +
     ':' +
     macAddress.slice(2, 4) +
@@ -49,10 +49,16 @@ export function createManagedDeviceEntity(
   }
   const macAddress: string[] = [];
   if (managedDevice.wiFiMacAddress) {
-    macAddress.push(managedDevice.wiFiMacAddress);
+    const normalizedMacAddress = normalizeMacAddress(
+      managedDevice.wiFiMacAddress,
+    );
+    macAddress.push(normalizedMacAddress);
   }
   if (managedDevice.ethernetMacAddress) {
-    macAddress.push(managedDevice.ethernetMacAddress);
+    const normalizedMacAddress = normalizeMacAddress(
+      managedDevice.ethernetMacAddress,
+    );
+    macAddress.push(normalizedMacAddress);
   }
   return createIntegrationEntity({
     entityData: {


### PR DESCRIPTION
The normalization of the `macAddress` property will allow for relevant mapping rules to match.