### PR TITLE
Release 6.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## Unreleased
 
+## 6.3.2 - 2022-07-12
+
+### Fixed
+
+- Integraiton no longer sets `jailBroken` to `true` when response from API is
+  `"jailBroken": "Unknown"`. It is now set to undefined.
+
 ## 6.3.1 - 2022-06-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-microsoft-365",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "A JupiterOne Integration for Microsoft 365",
   "license": "MPL-2.0",
   "main": "src/index.js",


### PR DESCRIPTION
# Description

Release 6.3.2 fixes `jailBroken` being set to `true` when `jailBroken` is "Unknown".