### PR TITLE
feat: add user uses relationship

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -180,6 +180,13 @@ The following relationships are created:
 | `azure_user`                  | **HAS**               | `smartphone`                   |
 | `azure_user`                  | **HAS**               | `user_endpoint`                |
 | `azure_user`                  | **HAS**               | `workstation`                  |
+| `azure_user`                  | **USES**              | `computer`                     |
+| `azure_user`                  | **USES**              | `desktop`                      |
+| `azure_user`                  | **USES**              | `laptop`                       |
+| `azure_user`                  | **USES**              | `server`                       |
+| `azure_user`                  | **USES**              | `smartphone`                   |
+| `azure_user`                  | **USES**              | `user_endpoint`                |
+| `azure_user`                  | **USES**              | `workstation`                  |
 | `computer`                    | **ASSIGNED**          | `intune_managed_application`   |
 | `computer`                    | **HAS**               | `intune_noncompliance_finding` |
 | `computer`                    | **INSTALLED**         | `intune_detected_application`  |

--- a/src/steps/intune/constants.ts
+++ b/src/steps/intune/constants.ts
@@ -106,6 +106,10 @@ export const relationships = {
     sourceType: activeDirectoryEntities.USER._type,
     _class: RelationshipClass.HAS,
   }),
+  MULTI_USER_USES_DEVICE: createRelationshipForAllDeviceTypes({
+    sourceType: activeDirectoryEntities.USER._type,
+    _class: RelationshipClass.USES,
+  }),
   MULTI_HOST_AGENT_MANAGES_DEVICE: createRelationshipForAllDeviceTypes({
     sourceType: entities.HOST_AGENT._type,
     _class: RelationshipClass.MANAGES,

--- a/src/steps/intune/steps/devices/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/intune/steps/devices/__tests__/__snapshots__/index.test.ts.snap
@@ -48,6 +48,14 @@ Array [
 exports[`fetchDevices With Active Directory: managedDeviceRelationshipsWithAD 1`] = `
 Array [
   Object {
+    "_class": "USES",
+    "_fromEntityKey": "001d35fc-dd2b-4d17-9ffc-3bafa265e7d9",
+    "_key": "001d35fc-dd2b-4d17-9ffc-3bafa265e7d9|uses|683dbff1-c8ff-4996-91ae-85484de46cfc",
+    "_toEntityKey": "683dbff1-c8ff-4996-91ae-85484de46cfc",
+    "_type": "azure_user_uses_smartphone",
+    "displayName": "USES",
+  },
+  Object {
     "_class": "HAS",
     "_fromEntityKey": "001d35fc-dd2b-4d17-9ffc-3bafa265e7d9",
     "_key": "001d35fc-dd2b-4d17-9ffc-3bafa265e7d9|has|683dbff1-c8ff-4996-91ae-85484de46cfc",

--- a/src/steps/intune/steps/devices/__tests__/index.test.ts
+++ b/src/steps/intune/steps/devices/__tests__/index.test.ts
@@ -38,8 +38,8 @@ describe('fetchDevices', () => {
       context.jobState.collectedRelationships.filter((r) =>
         managedDeviceTypes.some((type) => r._type.includes(type)),
       );
-    const userRelationships = managedDeviceRelationships.filter((r) =>
-      r._type.includes(activeDirectoryEntities.USER._type),
+    const userHasRelationships = managedDeviceRelationships.filter((r) =>
+      r._type.includes(activeDirectoryEntities.USER._type + '_has'),
     );
     const nonUserRelationships = managedDeviceRelationships.filter(
       (r) => !r._type.includes(activeDirectoryEntities.USER._type),
@@ -63,8 +63,8 @@ describe('fetchDevices', () => {
     expect(hostAgents).toMatchSnapshot('hostAgents'); // intentionally the same snapshot as in the 'With Active Directory' test below
 
     // Check that user relationships are mapped
-    expect(userRelationships.length).toBeGreaterThan(0);
-    userRelationships.forEach((r) =>
+    expect(userHasRelationships.length).toBeGreaterThan(0);
+    userHasRelationships.forEach((r) =>
       expect(r).toMatchObject({
         _mapping: expect.any(Object),
       }),
@@ -106,8 +106,12 @@ describe('fetchDevices', () => {
       context.jobState.collectedRelationships.filter((r) =>
         managedDeviceTypes.some((type) => r._type.includes(type)),
       );
-    const userRelationships = managedDeviceRelationships.filter((r) =>
-      r._type.includes(activeDirectoryEntities.USER._type),
+    const userHasRelationships = managedDeviceRelationships.filter((r) =>
+      r._type.includes(activeDirectoryEntities.USER._type + '_has'),
+    );
+
+    const userUsesRelationships = managedDeviceRelationships.filter((r) =>
+      r._type.includes(activeDirectoryEntities.USER._type + '_uses'),
     );
     const nonUserRelationships = managedDeviceRelationships.filter(
       (r) => !r._type.includes(activeDirectoryEntities.USER._type),
@@ -131,8 +135,12 @@ describe('fetchDevices', () => {
     expect(hostAgents).toMatchSnapshot('hostAgents'); // intentionally the same snapshot as in the 'Without Active Directory' test above
 
     // Check that user relationships are direct
-    expect(userRelationships.length).toBeGreaterThan(0);
-    expect(userRelationships).toMatchDirectRelationshipSchema({});
+    expect(userHasRelationships.length).toBeGreaterThan(0);
+    expect(userHasRelationships).toMatchDirectRelationshipSchema({});
+
+    // User uses relationships are present
+    expect(userUsesRelationships.length).toBeGreaterThan(0);
+
     // Check that the remaining relationships are with host agents
     expect(nonUserRelationships.length).toBeGreaterThan(0);
     nonUserRelationships.forEach((r) =>


### PR DESCRIPTION
# Description

This PR adds a new relationship for logged on users. This uses the `USES` relationship rather than the `HAS` relationship which is used for the device owner/registar.
